### PR TITLE
Add option to wait for rpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ You can get started using Apibara using one of the official SDKs:
  - [Python](https://www.apibara.com/docs/python-sdk)
 
 
+## Docker images
+
+We publish docker images on quay.io:
+
+ - [Starknet DNA](https://quay.io/repository/apibara/starknet?tab=tags)
+
+
 ## Running locally
 
 You can run the DNA servers locally using one of the provided docker images.

--- a/starknet/src/bin.rs
+++ b/starknet/src/bin.rs
@@ -33,6 +33,9 @@ struct StartCommand {
     /// Indexer name. Defaults to `starknet`.
     #[arg(long, env)]
     name: Option<String>,
+    /// Wait for RPC to be available before starting.
+    #[arg(long, env)]
+    wait_for_rpc: bool,
 }
 
 async fn start(args: StartCommand) -> Result<()> {
@@ -61,7 +64,7 @@ async fn start(args: StartCommand) -> Result<()> {
         }
     })?;
 
-    node.build()?.start(cts.clone()).await?;
+    node.build()?.start(cts.clone(), args.wait_for_rpc).await?;
 
     Ok(())
 }


### PR DESCRIPTION
Add a new `--wait-for-rpc` flag to wait for the rpc to become available
before starting ingesting data.
