### PR TITLE
adds --experimental_allow_proto3_optional

### DIFF
--- a/core/build.rs
+++ b/core/build.rs
@@ -9,12 +9,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .build_client(true)
         .build_server(true)
+        .protoc_arg("--experimental_allow_proto3_optional")
         .file_descriptor_set_path(out_dir.join(NODE_DESCRIPTOR_FILE))
         .compile(&["proto/node/v1alpha2/stream.proto"], &["proto/node"])?;
 
     tonic_build::configure()
         .build_client(true)
         .build_server(true)
+        .protoc_arg("--experimental_allow_proto3_optional")
         .file_descriptor_set_path(out_dir.join(STARKNET_DESCRIPTOR_FILE))
         .compile_well_known_types(true)
         .extern_path(".google.protobuf", "::pbjson_types")


### PR DESCRIPTION
The build was failing because of this flag not being present due to proto3

This just adds `.protoc_arg("--experimental_allow_proto3_optional")`