### PR TITLE
starknet: add non bidirectional stream methods

### DIFF
--- a/core/proto/node/v1alpha2/stream.proto
+++ b/core/proto/node/v1alpha2/stream.proto
@@ -4,8 +4,10 @@ syntax = "proto3";
 package apibara.node.v1alpha2;
 
 service Stream {
-  // Stream data from the node.
+  // Stream data from the node (bi-directional).
   rpc StreamData(stream StreamDataRequest) returns (stream StreamDataResponse);
+  // Stream data from the node.
+  rpc StreamDataImmutable(StreamDataRequest) returns (stream StreamDataResponse);
 }
 
 // Request data to be streamed.

--- a/starknet/src/server/stream.rs
+++ b/starknet/src/server/stream.rs
@@ -11,8 +11,6 @@ use apibara_core::node::v1alpha2::{stream_server, StreamDataRequest, StreamDataR
 use apibara_node::heartbeat::Heartbeat;
 use futures::Stream;
 use pin_project::pin_project;
-use tokio::sync::mpsc;
-use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Streaming};
 use tracing::warn;
 use tracing_futures::Instrument;
@@ -83,7 +81,7 @@ where
 
         let ingestion_stream = self.ingestion.subscribe().await;
         let ingestion_stream = IngestionStream::new(ingestion_stream);
-        
+
         let data_stream = DataStream::new(
             configuration_stream,
             ingestion_stream,
@@ -95,17 +93,19 @@ where
         let response = ResponseStream::new(data_stream).instrument(stream_span);
         Ok(Response::new(Box::pin(response)))
     }
-    
+
     async fn stream_data_immutable(
         &self,
         request: Request<StreamDataRequest>,
     ) -> Result<Response<Self::StreamDataImmutableStream>, tonic::Status> {
         let stream_span = self.request_observer.stream_data_span(request.metadata());
-        let stream_meter = self.request_observer.stream_data_meter(request.metadata());        
-        
+        let stream_meter = self.request_observer.stream_data_meter(request.metadata());
+
         let stream_data_request = request.into_inner();
-        let (inner_tx, inner_rx) = mpsc::channel::<Result<StreamDataRequest, tonic::Status>>(128);
-        let configuration_stream = ReceiverStream::new(inner_rx);
+
+        let configuration_stream = ImmutableRequestStream {
+            request: Some(stream_data_request),
+        };
         let configuration_stream = StreamConfigurationStream::new(configuration_stream);
 
         let ingestion_stream = self.ingestion.subscribe().await;
@@ -118,11 +118,28 @@ where
             self.healer.clone(),
             Arc::new(stream_meter),
         );
-        // inject configuration to stream
-        inner_tx.send(Ok(stream_data_request)).await;
 
         let response = ResponseStream::new(data_stream).instrument(stream_span);
         Ok(Response::new(Box::pin(response)))
+    }
+}
+
+/// A stream that yields the configuration once, and is pending forever after that.
+struct ImmutableRequestStream {
+    request: Option<StreamDataRequest>,
+}
+
+impl Stream for ImmutableRequestStream {
+    type Item = Result<StreamDataRequest, tonic::Status>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        _cx: &mut task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        match self.request.take() {
+            Some(request) => Poll::Ready(Some(Ok(request))),
+            None => Poll::Pending,
+        }
     }
 }
 


### PR DESCRIPTION
This PR add support to non bidirectional stream methods.
Close #94 

I didn't yet succeed to validate the correct behavior of my modification.
I think we could also reduce code duplication between `stream_data` and `stream_data_immutable`
