### PR TITLE
Lock down deno permissions

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -70,8 +70,8 @@ jobs:
         job:
         - os: ubuntu-22.04
           target: x86_64-unknown-linux-gnu
-        - os: macos-latest
-          target: x86_64-apple-darwin
+        # - os: macos-latest
+        #   target: x86_64-apple-darwin
     steps:
     - name: checkout sources
       uses: actions/checkout@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,7 @@ dependencies = [
  "bytesize",
  "clap",
  "ctrlc",
+ "dotenvy",
  "etcd-client",
  "exponential-backoff",
  "prost",
@@ -433,6 +434,7 @@ dependencies = [
  "deno_ast",
  "deno_core",
  "deno_runtime",
+ "dotenvy",
  "reqwest",
  "serde_json",
  "serde_v8",
@@ -2296,6 +2298,12 @@ dependencies = [
  "quote 0.6.13",
  "syn 0.15.44",
 ]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "downcast"
@@ -7304,6 +7312,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
+ "async-stream",
  "async-trait",
  "axum",
  "base64 0.21.2",
@@ -7318,7 +7327,10 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-native-certs",
+ "rustls-pemfile",
  "tokio 1.28.2",
+ "tokio-rustls 0.24.0",
  "tokio-stream",
  "tower",
  "tower-layer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,7 @@ dependencies = [
 name = "apibara-transformer"
 version = "0.1.0"
 dependencies = [
+ "assert_matches",
  "data-url",
  "deno_ast",
  "deno_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ byte-unit = "4.0.14"
 clap = { version = "4.3.3", features = ["derive", "env", "cargo", "unicode"] }
 ctrlc = { version = "3.2.3", features = ["termination"] }
 dirs = "4.0.0"
+dotenvy = "0.15.7"
 futures = "0.3.23"
 futures-util = "0.3.26"
 hex = { version = "0.4.3", features = ["serde"] }
@@ -56,7 +57,7 @@ testcontainers = "0.14.0"
 tokio = { version = "1.20.1", features = ["full"] }
 tokio-stream = { version = "0.1.10", features = ["sync"] }
 tokio-util = "0.7.4"
-tonic = "0.9.0"
+tonic = { version = "0.9.0", features = ["tls", "tls-roots", "prost" ] }
 tonic-build = "0.9.0"
 tonic-health = "0.9.0"
 tonic-reflection = "0.9.0"

--- a/sink-common/Cargo.toml
+++ b/sink-common/Cargo.toml
@@ -14,6 +14,7 @@ async-trait.workspace = true
 bytesize = {version = "1.1.0", features = ["serde"]}
 clap.workspace = true
 ctrlc.workspace = true
+dotenvy.workspace = true
 etcd-client = { version = "0.11.1" }
 exponential-backoff = "1.2.0"
 prost.workspace = true

--- a/sink-common/src/configuration.rs
+++ b/sink-common/src/configuration.rs
@@ -10,7 +10,7 @@ use apibara_sdk::{
     Configuration, InvalidMetadataKey, InvalidMetadataValue, MetadataKey, MetadataMap,
     MetadataValue,
 };
-use apibara_transformer::{Transformer, TransformerError};
+use apibara_transformer::{Transformer, TransformerError, TransformerOptions};
 use clap::Args;
 use prost::Message;
 use serde::de;
@@ -196,7 +196,8 @@ impl ConfigurationArgs {
     pub fn to_transformer(&self) -> Result<Option<Transformer>, TransformerError> {
         if let Some(transform) = &self.transform {
             let current_dir = std::env::current_dir().expect("current directory");
-            let transformer = Transformer::from_file(transform, current_dir)?;
+            let transformer =
+                Transformer::from_file(transform, current_dir, TransformerOptions::default())?;
             Ok(Some(transformer))
         } else {
             Ok(None)

--- a/transformer/Cargo.toml
+++ b/transformer/Cargo.toml
@@ -11,6 +11,7 @@ data-url = "0.2.0"
 deno_ast = { version = "0.26.0", features = ["cjs", "transpiling"] }
 deno_core = "0.189.0"
 deno_runtime = "0.115.0"
+dotenvy.workspace = true
 reqwest.workspace = true
 serde_json.workspace = true
 serde_v8 = "0.100.0"

--- a/transformer/Cargo.toml
+++ b/transformer/Cargo.toml
@@ -18,4 +18,5 @@ thiserror.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
+assert_matches.workspace = true
 tempfile.workspace = true

--- a/transformer/src/lib.rs
+++ b/transformer/src/lib.rs
@@ -1,4 +1,4 @@
 mod module_loader;
 mod transformer;
 
-pub use self::transformer::{Transformer, TransformerError, Value};
+pub use self::transformer::{Transformer, TransformerError, TransformerOptions, Value};

--- a/transformer/src/transformer.rs
+++ b/transformer/src/transformer.rs
@@ -36,6 +36,8 @@ pub enum TransformerError {
     V8Deserialization(#[from] serde_v8::Error),
     #[error("Transformer timed out: {0}")]
     Timeout(#[from] tokio::time::error::Elapsed),
+    #[error("Failed to load environment file: {0}")]
+    EnvironmentFile(#[from] dotenvy::Error),
 }
 
 #[derive(Debug, Default)]

--- a/transformer/src/transformer.rs
+++ b/transformer/src/transformer.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, path::Path, rc::Rc, time::Duration};
 
 use deno_core::{op, FastString, ModuleSpecifier, OpState, ZeroCopyBuf};
 use deno_runtime::{
-    permissions::PermissionsContainer,
+    permissions::{Permissions, PermissionsContainer, PermissionsOptions},
     worker::{MainWorker, WorkerOptions},
 };
 
@@ -50,9 +50,10 @@ impl Transformer {
     /// Creates a [Transformer] from the given module specifier.
     pub fn from_module(module: ModuleSpecifier) -> Result<Self, TransformerError> {
         let module_loader = WorkerModuleLoader::new();
+        let permissions = Self::default_permissions()?;
         let worker = MainWorker::bootstrap_from_options(
             module.clone(),
-            PermissionsContainer::allow_all(),
+            permissions,
             WorkerOptions {
                 module_loader: Rc::new(module_loader),
                 startup_snapshot: None,
@@ -106,6 +107,15 @@ impl Transformer {
                 Ok(value.value)
             }
         }
+    }
+
+    fn default_permissions() -> Result<PermissionsContainer, TransformerError> {
+        let permissions = Permissions::from_options(&PermissionsOptions {
+            allow_hrtime: true,
+            prompt: false,
+            ..PermissionsOptions::default()
+        })?;
+        Ok(PermissionsContainer::new(permissions))
     }
 }
 


### PR DESCRIPTION
For production usage, we want to limit the resources users can use and
for this we use deno's permissions.
