### PR TITLE
Optimize storage changes access

### DIFF
--- a/core/src/starknet/data.rs
+++ b/core/src/starknet/data.rs
@@ -69,6 +69,18 @@ impl FieldElement {
         }
     }
 
+    /// Returns a new field element from the raw byte representation.
+    pub fn from_slice(bytes: &[u8]) -> Result<Self, FieldElementDecodeError> {
+        // number is too big
+        let size = bytes.len();
+        if size > 32 {
+            return Err(FieldElementDecodeError::InvalidSize);
+        }
+        let mut bytes_array = [0u8; 32];
+        bytes_array[32 - size..].copy_from_slice(bytes);
+        Ok(FieldElement::from_bytes(&bytes_array))
+    }
+
     pub fn from_hex(s: &str) -> Result<Self, FieldElementDecodeError> {
         // must be at least 0x
         if !s.starts_with("0x") {
@@ -84,14 +96,7 @@ impl FieldElement {
             hex::decode(&s[2..])?
         };
 
-        // number is too big
-        let size = bytes.len();
-        if size > 32 {
-            return Err(FieldElementDecodeError::InvalidSize);
-        }
-        let mut bytes_array = [0u8; 32];
-        bytes_array[32 - size..].copy_from_slice(&bytes);
-        Ok(FieldElement::from_bytes(&bytes_array))
+        Self::from_slice(&bytes)
     }
 
     pub fn to_bytes(&self) -> [u8; 32] {

--- a/observability/src/lib.rs
+++ b/observability/src/lib.rs
@@ -40,9 +40,10 @@ pub fn meter(name: &'static str) -> Meter {
 pub fn init_opentelemetry() -> Result<(), OpenTelemetryInitError> {
     // The otel sdk doesn't follow the disabled env variable flag.
     // so we manually implement it to disable otel exports.
+    // we diverge from the spec by defaulting to disabled.
     let sdk_disabled = env::var(OTEL_SDK_DISABLED)
-        .map(|v| v == "true")
-        .unwrap_or(false);
+        .map(|v| v == "false")
+        .unwrap_or(true);
 
     if std::env::var("RUST_LOG").is_err() {
         std::env::set_var("RUST_LOG", "info");

--- a/starknet/src/db/mod.rs
+++ b/starknet/src/db/mod.rs
@@ -15,7 +15,7 @@ pub mod tables {
 
     pub use super::block::{BlockHeaderTable, BlockStatusTable};
     pub use super::chain::CanonicalChainTable;
-    pub use super::state::StateUpdateTable;
+    pub use super::state::{StateUpdateTable, StorageDiffTable};
     pub use super::transaction::{BlockBodyTable, BlockReceiptsTable};
 
     /// Ensures all tables exist.
@@ -26,6 +26,7 @@ pub mod tables {
         txn.ensure_table::<self::CanonicalChainTable>(None)?;
         txn.ensure_table::<self::BlockReceiptsTable>(None)?;
         txn.ensure_table::<self::StateUpdateTable>(None)?;
+        txn.ensure_table::<self::StorageDiffTable>(None)?;
         Ok(())
     }
 }

--- a/starknet/src/db/state.rs
+++ b/starknet/src/db/state.rs
@@ -1,13 +1,17 @@
 //! State update data.
 
 use apibara_core::starknet::v1alpha2;
-use apibara_node::db::Table;
+use apibara_node::db::{KeyDecodeError, Table, TableKey};
 
 use crate::core::GlobalBlockId;
 
-/// Store state updates.
+/// Store state updates without storage diffs.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct StateUpdateTable {}
+
+/// Store storage diffs for a given block.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct StorageDiffTable {}
 
 impl Table for StateUpdateTable {
     type Key = GlobalBlockId;
@@ -15,5 +19,46 @@ impl Table for StateUpdateTable {
 
     fn db_name() -> &'static str {
         "StateUpdate"
+    }
+}
+
+pub struct StorageDiffKey {
+    pub block_id: GlobalBlockId,
+    pub contract_address: v1alpha2::FieldElement,
+}
+
+impl Table for StorageDiffTable {
+    type Key = StorageDiffKey;
+    type Value = v1alpha2::StorageDiff;
+
+    fn db_name() -> &'static str {
+        "StorageDiff"
+    }
+}
+
+impl TableKey for StorageDiffKey {
+    type Encoded = [u8; 72];
+
+    fn encode(&self) -> Self::Encoded {
+        let mut out = [0; 72];
+        out[..40].copy_from_slice(&self.block_id.encode());
+        out[40..].copy_from_slice(&self.contract_address.to_bytes());
+        out
+    }
+
+    fn decode(b: &[u8]) -> Result<Self, apibara_node::db::KeyDecodeError> {
+        let block_id = GlobalBlockId::decode(&b[..40])?;
+
+        let contract_address = v1alpha2::FieldElement::from_slice(&b[40..]).map_err(|_| {
+            KeyDecodeError::InvalidByteSize {
+                expected: 72,
+                actual: b.len(),
+            }
+        })?;
+
+        Ok(StorageDiffKey {
+            block_id,
+            contract_address,
+        })
     }
 }


### PR DESCRIPTION
At the moment, some blocks have so many storage changes that trying to filter them sequentially results in very poor performance.
With this PR, we change the db layout to simplify filtering storage changes by contract address.
