### PR TITLE
starknet: add flag to change head refresh interval

### DIFF
--- a/starknet/src/ingestion/accepted.rs
+++ b/starknet/src/ingestion/accepted.rs
@@ -249,12 +249,13 @@ where
     async fn ingest_pending(&mut self) -> Result<(), BlockIngestionError> {
         // some node configurations don't support pending data.
         // in that case, simply ignore any error.
+        debug!("ingest pending block");
 
         let Some((status, mut header, body)) = self.provider.get_maybe_block(&BlockId::Pending).await else {
             return Ok(())
         };
 
-        // pending block is not what was expected. do nothing.
+        // pending block is not what was expected, do nothing.
         let is_next_pending_block = if let Some(hash) = header.parent_block_hash.as_ref() {
             *self.current_head.hash() == hash.into()
         } else {

--- a/starknet/tests/test_node.rs
+++ b/starknet/tests/test_node.rs
@@ -44,6 +44,7 @@ async fn test_starknet_reorgs() {
         ),
         wait_for_rpc: true,
         devnet: false,
+        head_refresh_interval_ms: None,
         use_metadata: Vec::default(),
         websocket_address: None,
     };

--- a/starknet/tests/test_reorgs.rs
+++ b/starknet/tests/test_reorgs.rs
@@ -38,6 +38,7 @@ async fn test_reorg_from_client_pov() {
                 wait_for_rpc: true,
                 devnet: true,
                 use_metadata: Vec::default(),
+                head_refresh_interval_ms: None,
                 websocket_address: None,
             };
             start_node(args, cts).await.unwrap();

--- a/starknet/tests/test_websockets.rs
+++ b/starknet/tests/test_websockets.rs
@@ -42,6 +42,7 @@ async fn test_reorg_from_client_pov_websockets() {
                 wait_for_rpc: true,
                 devnet: true,
                 use_metadata: Vec::default(),
+                head_refresh_interval_ms: None,
                 websocket_address: Some("127.0.0.1:8080".into()),
             };
             start_node(args, cts).await.unwrap();


### PR DESCRIPTION
**Summary**

Previously the value was hardcoded to 3 seconds because it made sense
for Starknet (public).
With Madara, this value is too high and needs to be customized based on
the chain's speed.

This PR adds a new `--head-refresh-internal-ms` flag to customize the
interval at which the ingestion components checks for new pending
blocks or heads.
