### PR TITLE
Replace anyhow with eyre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,9 +193,10 @@ checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 name = "apibara-cli"
 version = "0.1.0"
 dependencies = [
- "anyhow",
+ "apibara-observability",
  "apibara-sink-common",
  "clap",
+ "color-eyre",
  "serde",
  "tokio 1.28.2",
 ]
@@ -250,6 +260,7 @@ dependencies = [
 name = "apibara-observability"
 version = "0.1.0"
 dependencies = [
+ "color-eyre",
  "opentelemetry",
  "opentelemetry-otlp",
  "thiserror",
@@ -263,9 +274,9 @@ dependencies = [
 name = "apibara-operator"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "apibara-observability",
  "clap",
+ "color-eyre",
  "futures 0.3.28",
  "k8s-openapi",
  "kube",
@@ -324,7 +335,6 @@ name = "apibara-sink-common"
 version = "0.1.0"
 dependencies = [
  "anstyle",
- "anyhow",
  "apibara-core",
  "apibara-script",
  "apibara-sdk",
@@ -333,6 +343,7 @@ dependencies = [
  "async-trait",
  "bytesize",
  "clap",
+ "color-eyre",
  "ctrlc",
  "dotenvy",
  "etcd-client",
@@ -354,12 +365,12 @@ dependencies = [
 name = "apibara-sink-mongo"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "apibara-core",
  "apibara-observability",
  "apibara-sink-common",
  "async-trait",
  "clap",
+ "color-eyre",
  "mongodb",
  "serde",
  "serde_json",
@@ -393,13 +404,13 @@ dependencies = [
 name = "apibara-sink-parquet"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "apibara-core",
  "apibara-observability",
  "apibara-sink-common",
  "arrow",
  "async-trait",
  "clap",
+ "color-eyre",
  "parquet",
  "serde",
  "serde_json",
@@ -414,12 +425,12 @@ dependencies = [
 name = "apibara-sink-postgres"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "apibara-core",
  "apibara-observability",
  "apibara-sink-common",
  "async-trait",
  "clap",
+ "color-eyre",
  "serde",
  "serde_json",
  "thiserror",
@@ -433,12 +444,12 @@ dependencies = [
 name = "apibara-sink-webhook"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "apibara-core",
  "apibara-observability",
  "apibara-sink-common",
  "async-trait",
  "clap",
+ "color-eyre",
  "http",
  "prost",
  "reqwest",
@@ -454,7 +465,6 @@ dependencies = [
 name = "apibara-starknet"
 version = "1.0.2"
 dependencies = [
- "anyhow",
  "apibara-core",
  "apibara-node",
  "apibara-sdk",
@@ -464,6 +474,7 @@ dependencies = [
  "byteorder",
  "chrono",
  "clap",
+ "color-eyre",
  "ctrlc",
  "futures 0.3.28",
  "futures-channel",
@@ -962,6 +973,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "miniz_oxide 0.7.1",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1350,6 +1376,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "color-eyre"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba75b3d9449ecdccb27ecbc479fdc0b87fa2dd43d2f8298f9bf0e59aacc8dce"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
 ]
 
 [[package]]
@@ -2717,6 +2770,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2827,7 +2890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.5.4",
 ]
 
 [[package]]
@@ -3099,6 +3162,12 @@ dependencies = [
  "opaque-debug",
  "polyval",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "glob"
@@ -3496,6 +3565,12 @@ dependencies = [
  "quote 1.0.28",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
@@ -4213,6 +4288,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4582,6 +4666,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4708,6 +4801,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "p224"
@@ -5757,6 +5856,12 @@ dependencies = [
  "libsqlite3-sys",
  "smallvec 1.10.0",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"
@@ -7822,6 +7927,16 @@ checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ members = [
 
 [workspace.dependencies]
 assert_matches = "1.5.0"
-anyhow = "1.0.66"
 anstyle = "1.0.1"
 arrayvec = "0.7.2"
 async-stream = "0.3.5"
@@ -33,6 +32,7 @@ async-trait = "0.1.57"
 byteorder = "1.4.3"
 byte-unit = "4.0.14"
 clap = { version = "4.3.3", features = ["derive", "env", "cargo", "unicode", "color", "unstable-styles"] }
+color-eyre = "0.6"
 ctrlc = { version = "3.2.3", features = ["termination"] }
 dirs = "4.0.0"
 dotenvy = "0.15.7"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,8 +10,9 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
+apibara-observability = { path = "../observability" }
 apibara-sink-common = { path = "../sink-common" }
-anyhow.workspace = true
 clap.workspace = true
+color-eyre.workspace = true
 serde.workspace = true
 tokio.workspace = true

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,6 @@
 use std::{io::ErrorKind, process};
 
+use apibara_observability::{init_error_handler, init_opentelemetry};
 use apibara_sink_common::{
     apibara_cli_style, load_environment_variables, load_script, DotenvOptions,
     FullOptionsFromScript, ScriptOptions,
@@ -37,7 +38,7 @@ struct RunArgs {
     args: Vec<String>,
 }
 
-async fn run(args: RunArgs) -> anyhow::Result<()> {
+async fn run(args: RunArgs) -> color_eyre::eyre::Result<()> {
     // While not recommended, the script may return a different sink based on some env variable. We
     // need to load the environment variables before loading the script.
     let allow_env = load_environment_variables(&args.dotenv)?;
@@ -83,7 +84,10 @@ async fn run(args: RunArgs) -> anyhow::Result<()> {
 }
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> color_eyre::eyre::Result<()> {
+    init_error_handler()?;
+    init_opentelemetry()?;
+
     let args = Cli::parse();
     match args.subcommand {
         Command::Run(args) => run(args).await,

--- a/observability/Cargo.toml
+++ b/observability/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
+color-eyre.workspace = true
 opentelemetry.workspace = true
 opentelemetry-otlp.workspace = true
 thiserror.workspace = true

--- a/observability/src/lib.rs
+++ b/observability/src/lib.rs
@@ -23,6 +23,11 @@ pub use opentelemetry::metrics::{Counter, Meter};
 
 const OTEL_SDK_DISABLED: &str = "OTEL_SDK_DISABLED";
 
+/// Initialize the default panic and error reporter.
+pub fn init_error_handler() -> color_eyre::eyre::Result<()> {
+    color_eyre::install()
+}
+
 pub type BoxedLayer<S> = Box<dyn Layer<S> + Send + Sync>;
 
 #[derive(Debug, thiserror::Error)]

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -16,8 +16,8 @@ default = ["operator"]
 operator = []
 
 [dependencies]
-anyhow.workspace = true
 apibara-observability = { path = "../observability" }
+color-eyre.workspace = true
 clap.workspace = true
 futures.workspace = true
 k8s-openapi = { version = "0.18.0", features = ["v1_26", "api", "schemars"] }

--- a/operator/src/bin.rs
+++ b/operator/src/bin.rs
@@ -5,6 +5,7 @@ use apibara_operator::{
     sink::SinkWebhook,
 };
 use clap::{Args, Parser, Subcommand};
+use color_eyre::eyre::Result;
 use kube::{Client, CustomResourceExt};
 
 #[derive(Parser, Debug)]
@@ -32,7 +33,7 @@ struct StartArgs {
     pub sink_webhook_image: Option<String>,
 }
 
-fn generate_crds(_args: GenerateCrdArgs) -> anyhow::Result<()> {
+fn generate_crds(_args: GenerateCrdArgs) -> Result<()> {
     let crds = [SinkWebhook::crd()]
         .iter()
         .map(|crd| serde_yaml::to_string(&crd))
@@ -42,7 +43,7 @@ fn generate_crds(_args: GenerateCrdArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn start(args: StartArgs) -> anyhow::Result<()> {
+async fn start(args: StartArgs) -> Result<()> {
     let client = Client::try_default().await?;
     let configuration = args.to_configuration();
     controller::start(client, configuration).await?;
@@ -50,7 +51,7 @@ async fn start(args: StartArgs) -> anyhow::Result<()> {
 }
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> Result<()> {
     init_opentelemetry()?;
     let args = Cli::parse();
 

--- a/sink-common/Cargo.toml
+++ b/sink-common/Cargo.toml
@@ -8,13 +8,13 @@ license.workspace = true
 
 [dependencies]
 anstyle.workspace = true
-anyhow.workspace = true
 apibara-core = { path = "../core" }
 apibara-sdk = { path = "../sdk" }
 apibara-script = { path = "../script" }
 apibara-sink-options-derive = { path = "../sink-options-derive" }
 async-trait.workspace = true
 bytesize = {version = "1.1.0", features = ["serde"]}
+color-eyre.workspace = true
 clap.workspace = true
 ctrlc.workspace = true
 dotenvy.workspace = true

--- a/sink-common/src/cli.rs
+++ b/sink-common/src/cli.rs
@@ -25,7 +25,7 @@ pub fn load_script(path: &str, options: ScriptOptions) -> Result<Script, LoadScr
 }
 
 /// Connect the cancellation token to the ctrl-c handler.
-pub fn set_ctrlc_handler(ct: CancellationToken) -> anyhow::Result<()> {
+pub fn set_ctrlc_handler(ct: CancellationToken) -> color_eyre::eyre::Result<()> {
     ctrlc::set_handler({
         move || {
             ct.cancel();

--- a/sink-common/src/connector.rs
+++ b/sink-common/src/connector.rs
@@ -18,6 +18,7 @@ use crate::{
     cli::LoadScriptError,
     persistence::{Persistence, PersistenceClient, PersistenceError},
     status::StatusServer,
+    PersistenceOptionsError, StatusServerOptionsError, StreamOptionsError,
 };
 
 pub trait SinkOptions: DeserializeOwned {
@@ -67,7 +68,21 @@ pub struct SinkConnectorOptions {
 }
 
 #[derive(Debug, thiserror::Error)]
+pub enum OptionsError {
+    #[error("Failed to load persistence options: {0}")]
+    Persistence(#[from] PersistenceOptionsError),
+    #[error("Failed to load status server options: {0}")]
+    StatusServer(#[from] StatusServerOptionsError),
+    #[error("Failed to load stream options: {0}")]
+    Stream(#[from] StreamOptionsError),
+    #[error("Failed to load sink options: {0}")]
+    Sink(Box<dyn std::error::Error + Send + Sync + 'static>),
+}
+
+#[derive(Debug, thiserror::Error)]
 pub enum SinkConnectorError {
+    #[error(transparent)]
+    Options(#[from] OptionsError),
     #[error(transparent)]
     ClientBuilder(#[from] apibara_sdk::ClientBuilderError),
     #[error("Failed to send configuration")]

--- a/sink-mongo/Cargo.toml
+++ b/sink-mongo/Cargo.toml
@@ -15,11 +15,11 @@ name = "apibara-sink-mongo"
 path = "src/bin.rs"
 
 [dependencies]
-anyhow.workspace = true
 apibara-core = { path = "../core" }
 apibara-observability = { path = "../observability" }
 apibara-sink-common = { path = "../sink-common" }
 async-trait.workspace = true
+color-eyre.workspace = true
 clap.workspace = true
 mongodb = "2.5.0"
 serde.workspace = true

--- a/sink-mongo/src/bin.rs
+++ b/sink-mongo/src/bin.rs
@@ -1,4 +1,4 @@
-use apibara_observability::init_opentelemetry;
+use apibara_observability::{init_error_handler, init_opentelemetry};
 use apibara_sink_common::{run_sink_connector, set_ctrlc_handler, OptionsFromCli};
 use apibara_sink_mongo::{MongoSink, SinkMongoOptions};
 use clap::{Args, Parser, Subcommand};
@@ -27,7 +27,8 @@ struct RunArgs {
 }
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> color_eyre::eyre::Result<()> {
+    init_error_handler()?;
     init_opentelemetry()?;
     let args = Cli::parse();
 

--- a/sink-parquet/Cargo.toml
+++ b/sink-parquet/Cargo.toml
@@ -15,12 +15,12 @@ name = "apibara-sink-parquet"
 path = "src/bin.rs"
 
 [dependencies]
-anyhow.workspace = true
 apibara-core = { path = "../core" }
 apibara-observability = { path = "../observability" }
 apibara-sink-common = { path = "../sink-common" }
 arrow = { version = "41.0.0", default-features = false, features = ["arrow-json", "json"] }
 async-trait.workspace = true
+color-eyre.workspace = true
 clap.workspace = true
 parquet = { version = "41.0.0", default-features = false, features = ["arrow", "arrow-array", "arrow-schema"] }
 serde.workspace = true

--- a/sink-parquet/src/bin.rs
+++ b/sink-parquet/src/bin.rs
@@ -1,4 +1,4 @@
-use apibara_observability::init_opentelemetry;
+use apibara_observability::{init_error_handler, init_opentelemetry};
 use apibara_sink_common::{run_sink_connector, set_ctrlc_handler, OptionsFromCli};
 use apibara_sink_parquet::{ParquetSink, SinkParquetOptions};
 use clap::{Args, Parser, Subcommand};
@@ -27,7 +27,8 @@ struct RunArgs {
 }
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> color_eyre::eyre::Result<()> {
+    init_error_handler()?;
     init_opentelemetry()?;
     let args = Cli::parse();
 

--- a/sink-postgres/Cargo.toml
+++ b/sink-postgres/Cargo.toml
@@ -15,11 +15,11 @@ name = "apibara-sink-postgres"
 path = "src/bin.rs"
 
 [dependencies]
-anyhow.workspace = true
 apibara-core = { path = "../core" }
 apibara-observability = { path = "../observability" }
 apibara-sink-common = { path = "../sink-common" }
 async-trait.workspace = true
+color-eyre.workspace = true
 clap.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/sink-postgres/src/bin.rs
+++ b/sink-postgres/src/bin.rs
@@ -1,4 +1,4 @@
-use apibara_observability::init_opentelemetry;
+use apibara_observability::{init_error_handler, init_opentelemetry};
 use apibara_sink_common::{run_sink_connector, set_ctrlc_handler, OptionsFromCli};
 use apibara_sink_postgres::{PostgresSink, SinkPostgresOptions};
 use clap::{Args, Parser, Subcommand};
@@ -27,7 +27,8 @@ struct RunArgs {
 }
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> color_eyre::eyre::Result<()> {
+    init_error_handler()?;
     init_opentelemetry()?;
     let args = Cli::parse();
 

--- a/sink-webhook/Cargo.toml
+++ b/sink-webhook/Cargo.toml
@@ -15,11 +15,11 @@ name = "apibara-sink-webhook"
 path = "src/bin.rs"
 
 [dependencies]
-anyhow.workspace = true
 apibara-core = { path = "../core" }
 apibara-observability = { path = "../observability" }
 apibara-sink-common = { path = "../sink-common" }
 async-trait.workspace = true
+color-eyre.workspace = true
 clap.workspace = true
 http.workspace = true
 prost.workspace = true

--- a/sink-webhook/src/bin.rs
+++ b/sink-webhook/src/bin.rs
@@ -1,4 +1,4 @@
-use apibara_observability::init_opentelemetry;
+use apibara_observability::{init_error_handler, init_opentelemetry};
 use apibara_sink_common::{run_sink_connector, set_ctrlc_handler, OptionsFromCli};
 use apibara_sink_webhook::{SinkWebhookOptions, WebhookSink};
 use clap::{Args, Parser, Subcommand};
@@ -27,7 +27,8 @@ struct RunArgs {
 }
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> color_eyre::eyre::Result<()> {
+    init_error_handler()?;
     init_opentelemetry()?;
     let args = Cli::parse();
 

--- a/starknet/Cargo.toml
+++ b/starknet/Cargo.toml
@@ -15,7 +15,6 @@ name = "apibara-starknet"
 path = "src/bin.rs"
 
 [dependencies]
-anyhow.workspace = true
 apibara-core = { path = "../core" }
 apibara-node = { path = "../node" }
 apibara-sdk = { path = "../sdk" }
@@ -23,6 +22,7 @@ bloomfilter = "1.0.9"
 byte-unit.workspace = true
 byteorder.workspace = true
 chrono = "0.4.22"
+color-eyre.workspace = true
 clap.workspace = true
 ctrlc.workspace = true
 futures.workspace = true

--- a/starknet/src/bin.rs
+++ b/starknet/src/bin.rs
@@ -1,7 +1,7 @@
-use anyhow::Result;
-use apibara_node::o11y::init_opentelemetry;
+use apibara_node::o11y::{init_error_handler, init_opentelemetry};
 use apibara_starknet::{set_ctrlc_handler, start_node, StartArgs};
 use clap::{Parser, Subcommand};
+use color_eyre::eyre::Result;
 use tokio_util::sync::CancellationToken;
 
 #[derive(Parser)]
@@ -19,6 +19,7 @@ enum CliCommand {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    init_error_handler()?;
     init_opentelemetry()?;
 
     let cts = CancellationToken::new();

--- a/starknet/src/lib.rs
+++ b/starknet/src/lib.rs
@@ -19,9 +19,9 @@ use ingestion::BlockIngestionConfig;
 
 use std::{path::PathBuf, time::Duration};
 
-use anyhow::Result;
 use apibara_node::db::default_data_dir;
 use clap::Args;
+use color_eyre::eyre::Result;
 use tempdir::TempDir;
 use tokio_util::sync::CancellationToken;
 use tracing::info;


### PR DESCRIPTION
**Summary**

Now that we expect users to use Apibara from the CLI, we should display
more user-friendly error messages.
We use color-eyre to report errors since the default output is prettier
than anyhow.
