### PR TITLE
Create `apibara-cli` docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /result-bin
 /.devcontainer/.profile
 .pre-commit-config.yaml
+.envrc

--- a/flake.nix
+++ b/flake.nix
@@ -52,12 +52,18 @@
             volumes = {
               "/data" = { };
             };
+            ports = {
+              "8118/tcp" = { };
+            };
           };
           sink-mongo = {
             description = "Integration to populate a MongoDB collection with onchain data";
             path = ./sink-mongo;
             volumes = {
               "/data" = { };
+            };
+            ports = {
+              "8118/tcp" = { };
             };
           };
           sink-postgres = {
@@ -66,12 +72,35 @@
             volumes = {
               "/data" = { };
             };
+            ports = {
+              "8118/tcp" = { };
+            };
           };
           sink-parquet = {
             description = "Integration to generate a Parquet dataset from onchain data";
             path = ./sink-parquet;
             volumes = {
               "/data" = { };
+            };
+            ports = {
+              "8118/tcp" = { };
+            };
+          };
+          cli = {
+            description = "Apibara CLI tool";
+            path = ./cli;
+            binaryName = "apibara";
+            extraBinaries = [
+              "sink-webhook"
+              "sink-postgres"
+              "sink-mongo"
+              "sink-parquet"
+            ];
+            volumes = {
+              "/data" = { };
+            };
+            ports = {
+              "8118/tcp" = { };
             };
           };
         };


### PR DESCRIPTION
**Summary**

This container contains the `apibara` binary, together with the builtin `apibara-sink-*` binaries.
Developers can use this container to run `apibara` without having to use a separate container for each sink type.