### PR TITLE
Rename `--env-from-file` to `--allow-env`

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -55,11 +55,11 @@ async fn run(args: RunArgs) -> color_eyre::eyre::Result<()> {
     let sink_type = configuration.sink.sink_type;
     let sink_command = format!("apibara-sink-{}", sink_type);
 
-    // Add back the `--env-from-file` argument if specified.
+    // Add back the `--allow-env` argument if specified.
     let mut extra_args = args.args;
-    if let Some(env_from_file) = args.dotenv.env_from_file {
-        extra_args.push("--env-from-file".to_string());
-        extra_args.push(env_from_file.to_string_lossy().to_string());
+    if let Some(allow_env) = args.dotenv.allow_env {
+        extra_args.push("--allow-env".to_string());
+        extra_args.push(allow_env.to_string_lossy().to_string());
     };
 
     let command_res = process::Command::new(&sink_command)

--- a/sink-common/src/configuration.rs
+++ b/sink-common/src/configuration.rs
@@ -60,7 +60,7 @@ pub struct DotenvOptions {
     /// Notice that by default the script doesn't have access to any environment variable,
     /// only from the ones specified in this file.
     #[arg(long, env)]
-    pub env_from_file: Option<PathBuf>,
+    pub allow_env: Option<PathBuf>,
 }
 
 #[derive(Args, Debug, Default, Deserialize)]

--- a/sink-common/src/lib.rs
+++ b/sink-common/src/lib.rs
@@ -11,6 +11,7 @@ use std::env;
 use apibara_core::starknet::v1alpha2;
 use serde::Deserialize;
 use tokio_util::sync::CancellationToken;
+use tracing::debug;
 
 pub use self::cli::*;
 pub use self::configuration::*;
@@ -104,16 +105,17 @@ where
 pub fn load_environment_variables(
     options: &DotenvOptions,
 ) -> Result<Option<Vec<String>>, SinkConnectorError> {
-    let Some(env_from_file) = options.env_from_file.as_ref() else {
+    let Some(allow_env) = options.allow_env.as_ref() else {
         return Ok(None);
     };
 
-    let env_iter = dotenvy::from_path_iter(env_from_file)?;
+    let env_iter = dotenvy::from_path_iter(allow_env)?;
 
     let mut allow_env = vec![];
     for item in env_iter {
         let (key, value) = item?;
         allow_env.push(key.clone());
+        debug!(env = ?key, "allowing environment variable");
         env::set_var(key, value);
     }
 


### PR DESCRIPTION
**Summary**

This change is to reduce the confusion when accessing environment variables from Deno. Since Deno will show an error message mentioning `--allow-env`, it was confusing to explain that the flag is actually `--env-from-file` in Apibara. So, we rename the flag to match Deno's error message.