### PR TITLE
starknet: Add cli flag to rate-limit the blocks per second per stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,7 @@ dependencies = [
  "byteorder",
  "dirs",
  "futures 0.3.28",
+ "governor",
  "hyper 0.14.26",
  "lazy_static",
  "libmdbx",
@@ -3082,6 +3083,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3174,6 +3181,24 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "governor"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "821239e5672ff23e2a7060901fa622950bbd80b649cdaadd78d1c1767ed14eb4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dashmap",
+ "futures 0.3.28",
+ "futures-timer",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot 0.12.1",
+ "quanta",
+ "rand 0.8.5",
+ "smallvec 1.10.0",
+]
 
 [[package]]
 name = "group"
@@ -4156,6 +4181,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4506,6 +4540,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4514,6 +4554,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "normalize-line-endings"
@@ -5499,6 +5545,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17e662a7a8291a865152364c20c7abc5e60486ab2001e8ec10b24862de0b9ab"
+dependencies = [
+ "crossbeam-utils 0.8.15",
+ "libc",
+ "mach2",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5615,6 +5677,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.10",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "10.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ dirs = "4.0.0"
 dotenvy = "0.15.7"
 futures = "0.3.23"
 futures-util = "0.3.26"
+governor = "0.6.0"
 hex = { version = "0.4.3", features = ["serde"] }
 http = "0.2.9"
 hyper = "0.14.20"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -20,6 +20,7 @@ byte-unit.workspace = true
 byteorder.workspace = true
 dirs.workspace = true
 futures.workspace = true
+governor.workspace = true
 hyper.workspace = true
 lazy_static.workspace = true
 libmdbx = "0.1.7"

--- a/starknet/src/lib.rs
+++ b/starknet/src/lib.rs
@@ -43,6 +43,9 @@ pub struct StartArgs {
     /// Wait for RPC to be available before starting.
     #[arg(long, env)]
     pub wait_for_rpc: bool,
+    /// Set an upper bound on the number of blocks per second clients can stream.
+    #[arg(long, env)]
+    pub blocks_per_second_limit: Option<u32>,
     /// Create a temporary directory for data, deleted when devnet is closed.
     #[arg(long, env)]
     pub devnet: bool,
@@ -86,6 +89,10 @@ pub async fn start_node(args: StartArgs, cts: CancellationToken) -> Result<()> {
 
     if let Some(websocket_address) = args.websocket_address {
         node.with_websocket_address(websocket_address);
+    }
+
+    if let Some(limit) = args.blocks_per_second_limit {
+        node.with_blocks_per_second_limit(limit);
     }
 
     if let Some(head_refresh_interval_free) = args.head_refresh_interval_ms {

--- a/starknet/src/server/stream.rs
+++ b/starknet/src/server/stream.rs
@@ -25,6 +25,7 @@ use crate::{
 
 pub struct StreamService<R: StorageReader, O: RequestObserver> {
     ingestion: Arc<IngestionStreamClient>,
+    blocks_per_second_quota: u32,
     storage: Arc<R>,
     request_observer: O,
 }
@@ -34,12 +35,18 @@ where
     R: StorageReader + Send + Sync + 'static,
     O: RequestObserver,
 {
-    pub fn new(ingestion: Arc<IngestionStreamClient>, storage: R, request_observer: O) -> Self {
+    pub fn new(
+        ingestion: Arc<IngestionStreamClient>,
+        storage: R,
+        request_observer: O,
+        blocks_per_second_quota: u32,
+    ) -> Self {
         let storage = Arc::new(storage);
         StreamService {
             ingestion,
             storage,
             request_observer,
+            blocks_per_second_quota,
         }
     }
 
@@ -70,6 +77,7 @@ where
             ingestion_stream,
             cursor_producer,
             batch_producer,
+            self.blocks_per_second_quota,
             stream_meter,
         );
 

--- a/starknet/src/websocket.rs
+++ b/starknet/src/websocket.rs
@@ -17,6 +17,7 @@ use warp::Filter as WarpFilter;
 #[derive(Clone)]
 pub struct WebsocketStreamServer<R: StorageReader + Send + Sync + 'static> {
     address: String,
+    blocks_per_second_quota: u32,
     ingestion: Arc<IngestionStreamClient>,
     storage: Arc<R>,
 }
@@ -26,12 +27,14 @@ impl<R: StorageReader + Send + Sync + 'static> WebsocketStreamServer<R> {
         address: String,
         db: Arc<R>,
         ingestion: IngestionStreamClient,
+        blocks_per_second_quota: u32,
     ) -> WebsocketStreamServer<R> {
         let ingestion = Arc::new(ingestion);
         WebsocketStreamServer {
             address,
             ingestion,
             storage: db,
+            blocks_per_second_quota,
         }
     }
 
@@ -89,6 +92,7 @@ impl<R: StorageReader + Send + Sync + 'static> WebsocketStreamServer<R> {
             ingestion_stream,
             cursor_producer,
             batch_producer,
+            self.blocks_per_second_quota,
             meter,
         );
 

--- a/starknet/tests/test_node.rs
+++ b/starknet/tests/test_node.rs
@@ -46,6 +46,7 @@ async fn test_starknet_reorgs() {
         devnet: false,
         head_refresh_interval_ms: None,
         use_metadata: Vec::default(),
+        blocks_per_second_limit: None,
         websocket_address: None,
     };
 

--- a/starknet/tests/test_reorgs.rs
+++ b/starknet/tests/test_reorgs.rs
@@ -38,6 +38,7 @@ async fn test_reorg_from_client_pov() {
                 wait_for_rpc: true,
                 devnet: true,
                 use_metadata: Vec::default(),
+                blocks_per_second_limit: None,
                 head_refresh_interval_ms: None,
                 websocket_address: None,
             };

--- a/starknet/tests/test_websockets.rs
+++ b/starknet/tests/test_websockets.rs
@@ -44,6 +44,7 @@ async fn test_reorg_from_client_pov_websockets() {
                 use_metadata: Vec::default(),
                 head_refresh_interval_ms: None,
                 websocket_address: Some("127.0.0.1:8080".into()),
+                blocks_per_second_limit: None,
             };
             start_node(args, cts).await.unwrap();
         }


### PR DESCRIPTION
**Summary**

Unlimited streaming speed creates the issue where some users can exhaust the server's resources by streaming blocks at a very high rate. This commit adds a cli flag to limit the number of blocks per second per stream.