### PR TITLE
Build universal linux binaries

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -130,6 +130,10 @@
 
         # all packages.
         # show them with `nix flake show`.
+        # there's three packages for each crate:
+        #  - the binary compiled for the current nix system.
+        # - `-image`: a docker image with the binary.
+        # - `-universal`: a binary that runs on non-nix systems.
         # build with `nix build .#<name>`.
         packages = (native.packages // { });
       }


### PR DESCRIPTION
**Summary**

Add a `-universal` derivation for each crate that patches the binary produced by nix to work on all linux platforms.