### PR TITLE
Add support for reverted transactions and RPC v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6350,6 +6350,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json_pythonic"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62212da9872ca2a0cad0093191ee33753eddff9266cbbc1b4a602d13a3a768db"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6673,12 +6684,14 @@ dependencies = [
 
 [[package]]
 name = "starknet"
-version = "0.3.0"
-source = "git+https://github.com/fracek/starknet-rs?rev=e1c33fc277#e1c33fc277635ebe4954126761869908ab6ebcbe"
+version = "0.5.0"
+source = "git+https://github.com/fracek/starknet-rs?rev=8e3e7272b#8e3e7272b741c5d09eedb3eafce418d741a28de1"
 dependencies = [
  "starknet-accounts",
  "starknet-contract",
  "starknet-core",
+ "starknet-crypto",
+ "starknet-ff",
  "starknet-macros",
  "starknet-providers",
  "starknet-signers",
@@ -6686,8 +6699,8 @@ dependencies = [
 
 [[package]]
 name = "starknet-accounts"
-version = "0.2.0"
-source = "git+https://github.com/fracek/starknet-rs?rev=e1c33fc277#e1c33fc277635ebe4954126761869908ab6ebcbe"
+version = "0.4.0"
+source = "git+https://github.com/fracek/starknet-rs?rev=8e3e7272b#8e3e7272b741c5d09eedb3eafce418d741a28de1"
 dependencies = [
  "async-trait",
  "starknet-core",
@@ -6698,8 +6711,8 @@ dependencies = [
 
 [[package]]
 name = "starknet-contract"
-version = "0.2.0"
-source = "git+https://github.com/fracek/starknet-rs?rev=e1c33fc277#e1c33fc277635ebe4954126761869908ab6ebcbe"
+version = "0.4.0"
+source = "git+https://github.com/fracek/starknet-rs?rev=8e3e7272b#8e3e7272b741c5d09eedb3eafce418d741a28de1"
 dependencies = [
  "serde",
  "serde_json",
@@ -6712,26 +6725,25 @@ dependencies = [
 
 [[package]]
 name = "starknet-core"
-version = "0.3.2"
-source = "git+https://github.com/fracek/starknet-rs?rev=e1c33fc277#e1c33fc277635ebe4954126761869908ab6ebcbe"
+version = "0.5.1"
+source = "git+https://github.com/fracek/starknet-rs?rev=8e3e7272b#8e3e7272b741c5d09eedb3eafce418d741a28de1"
 dependencies = [
  "base64 0.21.2",
- "ethereum-types",
  "flate2",
  "hex",
  "serde",
  "serde_json",
+ "serde_json_pythonic",
  "serde_with 2.3.3",
  "sha3",
  "starknet-crypto",
  "starknet-ff",
- "thiserror",
 ]
 
 [[package]]
 name = "starknet-crypto"
-version = "0.5.1"
-source = "git+https://github.com/fracek/starknet-rs?rev=e1c33fc277#e1c33fc277635ebe4954126761869908ab6ebcbe"
+version = "0.6.0"
+source = "git+https://github.com/fracek/starknet-rs?rev=8e3e7272b#8e3e7272b741c5d09eedb3eafce418d741a28de1"
 dependencies = [
  "crypto-bigint 0.5.2",
  "hex",
@@ -6749,8 +6761,8 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto-codegen"
-version = "0.3.1"
-source = "git+https://github.com/fracek/starknet-rs?rev=e1c33fc277#e1c33fc277635ebe4954126761869908ab6ebcbe"
+version = "0.3.2"
+source = "git+https://github.com/fracek/starknet-rs?rev=8e3e7272b#8e3e7272b741c5d09eedb3eafce418d741a28de1"
 dependencies = [
  "starknet-curve",
  "starknet-ff",
@@ -6759,8 +6771,8 @@ dependencies = [
 
 [[package]]
 name = "starknet-curve"
-version = "0.3.0"
-source = "git+https://github.com/fracek/starknet-rs?rev=e1c33fc277#e1c33fc277635ebe4954126761869908ab6ebcbe"
+version = "0.4.0"
+source = "git+https://github.com/fracek/starknet-rs?rev=8e3e7272b#8e3e7272b741c5d09eedb3eafce418d741a28de1"
 dependencies = [
  "starknet-ff",
 ]
@@ -6768,7 +6780,7 @@ dependencies = [
 [[package]]
 name = "starknet-ff"
 version = "0.3.4"
-source = "git+https://github.com/fracek/starknet-rs?rev=e1c33fc277#e1c33fc277635ebe4954126761869908ab6ebcbe"
+source = "git+https://github.com/fracek/starknet-rs?rev=8e3e7272b#8e3e7272b741c5d09eedb3eafce418d741a28de1"
 dependencies = [
  "ark-ff",
  "bigdecimal",
@@ -6781,8 +6793,8 @@ dependencies = [
 
 [[package]]
 name = "starknet-macros"
-version = "0.1.0"
-source = "git+https://github.com/fracek/starknet-rs?rev=e1c33fc277#e1c33fc277635ebe4954126761869908ab6ebcbe"
+version = "0.1.2"
+source = "git+https://github.com/fracek/starknet-rs?rev=8e3e7272b#8e3e7272b741c5d09eedb3eafce418d741a28de1"
 dependencies = [
  "starknet-core",
  "syn 2.0.18",
@@ -6790,12 +6802,14 @@ dependencies = [
 
 [[package]]
 name = "starknet-providers"
-version = "0.3.0"
-source = "git+https://github.com/fracek/starknet-rs?rev=e1c33fc277#e1c33fc277635ebe4954126761869908ab6ebcbe"
+version = "0.5.0"
+source = "git+https://github.com/fracek/starknet-rs?rev=8e3e7272b#8e3e7272b741c5d09eedb3eafce418d741a28de1"
 dependencies = [
  "async-trait",
  "auto_impl",
+ "ethereum-types",
  "flate2",
+ "log",
  "reqwest",
  "serde",
  "serde_json",
@@ -6807,8 +6821,8 @@ dependencies = [
 
 [[package]]
 name = "starknet-signers"
-version = "0.2.1"
-source = "git+https://github.com/fracek/starknet-rs?rev=e1c33fc277#e1c33fc277635ebe4954126761869908ab6ebcbe"
+version = "0.3.0"
+source = "git+https://github.com/fracek/starknet-rs?rev=8e3e7272b#8e3e7272b741c5d09eedb3eafce418d741a28de1"
 dependencies = [
  "async-trait",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,14 +52,15 @@ pbjson-build = "0.5.1"
 pbjson-types = "0.5.1"
 pin-project = "1.0.12"
 prost = "0.11.0"
-reqwest = { version = "0.11.16", default-features = false, features = ["serde_json", "rustls-tls"] }
+reqwest = { version = "0.11.16", default-features = false, features = ["json", "serde_json", "rustls-tls"] }
 regex = "1.9.1"
 serde = "1.0.155"
 serde_json = "1.0.94"
 # starknet = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "c5cf1967d44dd" }
 # - relax flate2 dependency
-# - fix declare txn v0 deserialization
-starknet = { git = "https://github.com/fracek/starknet-rs", rev = "e1c33fc277" }
+# - relax log dependency
+# - hotfix for starknet v0.12.1
+starknet = { git = "https://github.com/fracek/starknet-rs", rev = "8e3e7272b" }
 thiserror = "1.0.32"
 tempfile = "3.3.0"
 tempdir = "0.3.7"

--- a/core/proto/starknet/v1alpha2/filter.proto
+++ b/core/proto/starknet/v1alpha2/filter.proto
@@ -36,6 +36,9 @@ message TransactionFilter {
     L1HandlerTransactionFilter l1_handler = 5;
     DeployAccountTransactionFilter deploy_account = 6;
   }
+
+  // Include reverted transactions.
+  bool include_reverted = 7;
 }
 
 // Receive invoke transactions, v0
@@ -100,6 +103,8 @@ message L2ToL1MessageFilter {
   FieldElement to_address = 1;
   // Filter payloads that prefix-match the given data.
   repeated FieldElement payload = 2;
+  // Include messages sent by reverted transactions.
+  bool include_reverted = 3;
 }
 
 // Filter events.
@@ -110,6 +115,8 @@ message EventFilter {
   repeated FieldElement keys = 2;
   // Filter data that prefix-match the given data.
   repeated FieldElement data = 3;
+  // Include events emitted by reverted transactions.
+  bool include_reverted = 4;
 }
 
 // Filter state update data.

--- a/core/proto/starknet/v1alpha2/starknet.proto
+++ b/core/proto/starknet/v1alpha2/starknet.proto
@@ -152,6 +152,16 @@ message DeployAccountTransaction {
   FieldElement class_hash = 4;
 }
 
+// Transaction execution status.
+enum ExecutionStatus {
+  // Unknown execution status.
+  EXECUTION_STATUS_UNSPECIFIED = 0;
+  // Transaction succeeded.
+  EXECUTION_STATUS_SUCCEEDED = 1;
+  // Transaction reverted.
+  EXECUTION_STATUS_REVERTED = 2;
+}
+
 // Result of the execution of a transaction.
 //
 // This message only contains the receipt data, if you also need the
@@ -169,6 +179,10 @@ message TransactionReceipt {
   repeated Event events = 5;
   // Address of the contract that was created by the transaction.
   FieldElement contract_address = 6;
+  // Transaction execution status.
+  ExecutionStatus execution_status = 7;
+  // The reason why the transaction reverted.
+  string revert_reason = 8;
 }
 
 // Message sent from L2 to L1 together with its transaction and receipt.

--- a/starknet/src/stream/batch_producer.rs
+++ b/starknet/src/stream/batch_producer.rs
@@ -149,6 +149,11 @@ where
             .into_iter()
             .zip(receipts.into_iter())
             .flat_map(|(tx, rx)| {
+                // For now, never include reverted transactions.
+                // TODO: use filter flag.
+                if rx.execution_status == v1alpha2::ExecutionStatus::Reverted as i32 {
+                    return None;
+                }
                 if self.filter_transaction(&tx) {
                     Some(v1alpha2::TransactionWithReceipt {
                         transaction: Some(tx),
@@ -189,6 +194,10 @@ where
         let events = filter_events_span.in_scope(|| {
             let mut events = Vec::default();
             for receipt in &receipts {
+                // TODO: use filter flag.
+                if receipt.execution_status == v1alpha2::ExecutionStatus::Reverted as i32 {
+                    continue;
+                }
                 let transaction = &transactions[receipt.transaction_index as usize];
                 for event in &receipt.events {
                     if self.filter_event(event) {
@@ -230,6 +239,10 @@ where
 
         let mut messages = Vec::default();
         for receipt in &receipts {
+            // TODO: use filter flag.
+            if receipt.execution_status == v1alpha2::ExecutionStatus::Reverted as i32 {
+                continue;
+            }
             let transaction = &transactions[receipt.transaction_index as usize];
             for message in &receipt.l2_to_l1_messages {
                 if self.filter_l2_to_l1_message(message) {

--- a/starknet/tests/test_node.rs
+++ b/starknet/tests/test_node.rs
@@ -18,7 +18,8 @@ use tracing::info;
 
 use common::{Devnet, DevnetClient};
 
-#[tokio::test]
+// Starknet-devnet doesn't support RCP 0.4 yet
+// #[tokio::test]
 #[ignore]
 async fn test_starknet_reorgs() {
     init_opentelemetry().unwrap();

--- a/starknet/tests/test_reorgs.rs
+++ b/starknet/tests/test_reorgs.rs
@@ -17,7 +17,8 @@ use tracing::info;
 
 use common::{Devnet, DevnetClient};
 
-#[tokio::test]
+// Starknet-devnet doesn't support RCP 0.4 yet
+// #[tokio::test]
 #[ignore]
 async fn test_reorg_from_client_pov() {
     init_opentelemetry().unwrap();


### PR DESCRIPTION
**Summary**

Starknet v0.12.1 includes reverted transactions in blocks. This commit adds support for ingesting reverted transactions, but not for streaming them.