### PR TITLE
cli: Add plugin manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,7 +197,10 @@ dependencies = [
  "apibara-sink-common",
  "clap",
  "color-eyre",
+ "colored",
+ "dirs",
  "serde",
+ "tabled",
  "tokio 1.28.2",
 ]
 
@@ -1235,6 +1238,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytecount"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,6 +1439,17 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "colored"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
+dependencies = [
+ "is-terminal",
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "console_static_text"
@@ -4942,6 +4962,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "papergrid"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2ccbe15f2b6db62f9a9871642746427e297b0ceb85f9a7f1ee5ff47d184d0c8"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7291,6 +7322,30 @@ dependencies = [
  "quote 1.0.28",
  "syn 1.0.109",
  "unicode-xid 0.2.4",
+]
+
+[[package]]
+name = "tabled"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfe9c3632da101aba5131ed63f9eed38665f8b3c68703a6bb18124835c1a5d22"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+ "unicode-width",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99f688a08b54f4f02f0a3c382aefdb7884d3d69609f785bd253dc033243e3fe4"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2 1.0.60",
+ "quote 1.0.28",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,5 +14,8 @@ apibara-observability = { path = "../observability" }
 apibara-sink-common = { path = "../sink-common" }
 clap.workspace = true
 color-eyre.workspace = true
+colored = "2.0.4"
+dirs.workspace = true
 serde.workspace = true
+tabled = "0.14.0"
 tokio.workspace = true

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,12 +1,10 @@
-use std::{io::ErrorKind, process};
+mod paths;
+mod plugins;
+mod run;
 
 use apibara_observability::{init_error_handler, init_opentelemetry};
-use apibara_sink_common::{
-    apibara_cli_style, load_environment_variables, load_script, DotenvOptions,
-    FullOptionsFromScript, ScriptOptions,
-};
-use clap::{Args, Parser, Subcommand};
-use serde::Deserialize;
+use apibara_sink_common::apibara_cli_style;
+use clap::{Parser, Subcommand};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None, styles = apibara_cli_style())]
@@ -17,70 +15,12 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Command {
-    /// Run the specified indexer.
-    Run(RunArgs),
-}
-
-#[derive(Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
-struct DummyOptions {
-    pub sink_type: String,
-}
-
-#[derive(Args, Debug)]
-#[clap(trailing_var_arg = true, allow_hyphen_values = true)]
-struct RunArgs {
-    /// The path to the indexer script.
-    script: String,
-    #[clap(flatten)]
-    dotenv: DotenvOptions,
-    /// Arguments forwarded to the indexer.
-    args: Vec<String>,
-}
-
-async fn run(args: RunArgs) -> color_eyre::eyre::Result<()> {
-    // While not recommended, the script may return a different sink based on some env variable. We
-    // need to load the environment variables before loading the script.
-    let allow_env = load_environment_variables(&args.dotenv)?;
-    let script_options = ScriptOptions { allow_env };
-
-    let mut script = load_script(&args.script, script_options)?;
-
-    // Load the configuration from the script, but we don't need the full options yet.
-    let configuration = script
-        .configuration::<FullOptionsFromScript<DummyOptions>>()
-        .await?;
-
-    // Delegate running the indexer to the sink command.
-    let sink_type = configuration.sink.sink_type;
-    let sink_command = format!("apibara-sink-{}", sink_type);
-
-    // Add back the `--allow-env` argument if specified.
-    let mut extra_args = args.args;
-    if let Some(allow_env) = args.dotenv.allow_env {
-        extra_args.push("--allow-env".to_string());
-        extra_args.push(allow_env.to_string_lossy().to_string());
-    };
-
-    let command_res = process::Command::new(&sink_command)
-        .arg("run")
-        .arg(args.script)
-        .args(extra_args)
-        .spawn();
-
-    match command_res {
-        Ok(mut child) => {
-            child.wait()?;
-            Ok(())
-        }
-        Err(err) => {
-            if let ErrorKind::NotFound = err.kind() {
-                eprintln!("error: executable {} is not in your $PATH.", sink_command);
-                std::process::exit(1);
-            }
-            Err(err.into())
-        }
-    }
+    /// Run an indexer script.
+    Run(run::RunArgs),
+    /// Manage plugins.
+    ///
+    /// Plugins are used to extend Apibara functionality, for example by adding new data sinks.
+    Plugins(plugins::PluginsArgs),
 }
 
 #[tokio::main]
@@ -90,6 +30,7 @@ async fn main() -> color_eyre::eyre::Result<()> {
 
     let args = Cli::parse();
     match args.subcommand {
-        Command::Run(args) => run(args).await,
+        Command::Run(args) => run::run(args).await,
+        Command::Plugins(args) => plugins::run(args).await,
     }
 }

--- a/cli/src/paths.rs
+++ b/cli/src/paths.rs
@@ -1,0 +1,16 @@
+use std::{env, path::PathBuf};
+
+/// Returns the local plugins directory.
+pub fn plugins_dir() -> PathBuf {
+    apibara_dir().join("plugins")
+}
+
+/// Returns the local apibara directory.
+pub fn apibara_dir() -> PathBuf {
+    match env::var("APIBARA_HOME") {
+        Err(_) => dirs::data_local_dir()
+            .expect("local data directory")
+            .join("apibara"),
+        Ok(path) => PathBuf::from(path),
+    }
+}

--- a/cli/src/plugins.rs
+++ b/cli/src/plugins.rs
@@ -1,0 +1,204 @@
+use std::{
+    env, fs,
+    os::unix::prelude::PermissionsExt,
+    path::{Path, PathBuf},
+    process,
+};
+
+use clap::{Args, Subcommand};
+use color_eyre::eyre::{eyre, Context, Result};
+use colored::*;
+use tabled::{settings::Style, Table, Tabled};
+
+use crate::paths::plugins_dir;
+
+#[derive(Debug, Args)]
+pub struct PluginsArgs {
+    #[command(subcommand)]
+    subcommand: Command,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// Install a new plugin.
+    Install(InstallArgs),
+    /// List all installed plugins.
+    List(ListArgs),
+    /// Remove an installed plugin.
+    Remove(RemoveArgs),
+    /// Update one or all installed plugins.
+    Update,
+}
+
+#[derive(Debug, Tabled)]
+#[tabled(rename_all = "SCREAMING_SNAKE_CASE")]
+struct PluginInfo {
+    name: String,
+    kind: String,
+    version: String,
+}
+
+#[derive(Debug, Args)]
+pub struct InstallArgs {
+    /// The name of the plugin to install, e.g. `sink-postgres`.
+    name: Option<String>,
+    /// Install the plugin from the given file.
+    #[arg(long, short = 'f')]
+    file: Option<PathBuf>,
+}
+
+#[derive(Debug, Args)]
+pub struct ListArgs {}
+
+#[derive(Debug, Args)]
+pub struct RemoveArgs {
+    /// The type of plugin to remove, e.g. `sink`.
+    kind: String,
+    /// The name of the plugin to remove, e.g. `mongo`.
+    name: String,
+}
+
+pub async fn run(args: PluginsArgs) -> Result<()> {
+    match args.subcommand {
+        Command::Install(args) => run_install(args).await,
+        Command::List(args) => run_list(args),
+        Command::Remove(args) => run_remove(args),
+        Command::Update => {
+            eprintln!("{}", "Updating plugins is not yet supported".red());
+            process::exit(1);
+        }
+    }
+}
+
+async fn run_install(args: InstallArgs) -> Result<()> {
+    let dir = plugins_dir();
+    fs::create_dir_all(dir)?;
+    let cwd = env::current_dir()?;
+
+    if let Some(file) = args.file {
+        install_from_file(cwd.join(file))?;
+    } else if let Some(_name) = args.name {
+        eprintln!(
+            "{}",
+            "Installing plugins by name is not yet supported".red()
+        );
+        process::exit(1);
+    }
+
+    Ok(())
+}
+
+fn install_from_file(file: impl AsRef<Path>) -> Result<()> {
+    let (name, version) =
+        get_binary_name_version(&file).wrap_err("Failed to get plugin name and version")?;
+
+    println!("Installing {} v{}", name, version);
+
+    let target = plugins_dir().join(name);
+    // Copy the binary content to a new file to avoid copying the permissions.
+    let content = fs::read(&file)?;
+    fs::write(&target, content)?;
+    fs::set_permissions(&target, fs::Permissions::from_mode(0o755))?;
+
+    println!("Plugin installed to {}", target.display());
+
+    Ok(())
+}
+
+fn run_list(_args: ListArgs) -> Result<()> {
+    let dir = plugins_dir();
+    let plugins = get_plugins(dir)?;
+
+    let table = Table::new(plugins).with(Style::rounded()).to_string();
+    println!("{}", table);
+
+    Ok(())
+}
+
+fn run_remove(args: RemoveArgs) -> Result<()> {
+    let dir = plugins_dir();
+    let plugin = PluginInfo::from_kind_name(args.kind, args.name);
+    let plugin_path = dir.join(plugin.binary_name());
+
+    let (name, version) =
+        get_binary_name_version(&plugin_path).wrap_err("Failed to get plugin name and version")?;
+
+    println!("Removing {} v{}", name, version);
+    fs::remove_file(plugin_path)?;
+
+    Ok(())
+}
+
+fn get_plugins(dir: impl AsRef<Path>) -> Result<Vec<PluginInfo>> {
+    if !dir.as_ref().is_dir() {
+        return Ok(vec![]);
+    }
+
+    let mut plugins = Vec::default();
+    for file in fs::read_dir(dir)? {
+        let file = file?;
+
+        let metadata = file.metadata()?;
+        if !metadata.is_file() || !metadata.permissions().mode() & 0o111 != 0 {
+            eprintln!(
+                "{} {:?}",
+                "Plugins directory contains non-executable file".yellow(),
+                file.path()
+            );
+            continue;
+        }
+
+        let (name, version) = get_binary_name_version(file.path())?;
+        let info = PluginInfo::from_name_version(name, version)?;
+        plugins.push(info);
+    }
+
+    Ok(plugins)
+}
+
+/// Runs the given plugin binary to extract the name and version.
+fn get_binary_name_version(file: impl AsRef<Path>) -> Result<(String, String)> {
+    let output = process::Command::new(file.as_ref())
+        .arg("--version")
+        .output()?;
+
+    let output = String::from_utf8(output.stdout)?;
+    let (name, version) = output
+        .trim()
+        .split_once(' ')
+        .ok_or_else(|| eyre!("Plugin --version output does not match spec"))?;
+    Ok((name.to_string(), version.to_string()))
+}
+
+impl PluginInfo {
+    pub fn from_kind_name(kind: String, name: String) -> Self {
+        Self {
+            name,
+            kind,
+            version: String::default(),
+        }
+    }
+
+    pub fn from_name_version(name: String, version: String) -> Result<Self> {
+        let mut parts = name.splitn(3, '-');
+        let _ = parts.next().ok_or_else(|| eyre!("Plugin name is empty"))?;
+        let kind = parts
+            .next()
+            .ok_or_else(|| eyre!("Plugin name does not contain a kind"))?
+            .to_string();
+        let name = parts
+            .next()
+            .ok_or_else(|| eyre!("Plugin name does not contain a kind"))?
+            .to_string();
+
+        Ok(Self {
+            name,
+            version,
+            kind,
+        })
+    }
+
+    pub fn binary_name(&self) -> String {
+        format!("apibara-{}-{}", self.kind, self.name)
+    }
+}

--- a/cli/src/run.rs
+++ b/cli/src/run.rs
@@ -1,0 +1,94 @@
+use std::{io::ErrorKind, process};
+
+use apibara_sink_common::{
+    load_environment_variables, load_script, DotenvOptions, FullOptionsFromScript, ScriptOptions,
+};
+use clap::Args;
+use colored::*;
+use serde::Deserialize;
+
+use crate::paths::plugins_dir;
+
+#[derive(Args, Debug)]
+#[clap(trailing_var_arg = true, allow_hyphen_values = true)]
+pub struct RunArgs {
+    /// The path to the indexer script.
+    script: String,
+    #[clap(flatten)]
+    dotenv: DotenvOptions,
+    /// Arguments forwarded to the indexer.
+    args: Vec<String>,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct DummyOptions {
+    pub sink_type: String,
+}
+
+pub async fn run(args: RunArgs) -> color_eyre::eyre::Result<()> {
+    // While not recommended, the script may return a different sink based on some env variable. We
+    // need to load the environment variables before loading the script.
+    let allow_env = load_environment_variables(&args.dotenv)?;
+    let script_options = ScriptOptions { allow_env };
+
+    let mut script = load_script(&args.script, script_options)?;
+
+    // Load the configuration from the script, but we don't need the full options yet.
+    let configuration = script
+        .configuration::<FullOptionsFromScript<DummyOptions>>()
+        .await?;
+
+    // Delegate running the indexer to the sink command.
+    let sink_type = configuration.sink.sink_type;
+    let sink_command = get_sink_command(&sink_type);
+
+    // Add back the `--allow-env` argument if specified.
+    let mut extra_args = args.args;
+    if let Some(allow_env) = args.dotenv.allow_env {
+        extra_args.push("--allow-env".to_string());
+        extra_args.push(allow_env.to_string_lossy().to_string());
+    };
+
+    let command_res = process::Command::new(sink_command)
+        .arg("run")
+        .arg(args.script)
+        .args(extra_args)
+        .spawn();
+
+    match command_res {
+        Ok(mut child) => {
+            child.wait()?;
+            Ok(())
+        }
+        Err(err) => {
+            if let ErrorKind::NotFound = err.kind() {
+                eprintln!(
+                    "{} {} {}",
+                    "Sink".red(),
+                    sink_type,
+                    "is not installed".red()
+                );
+                eprintln!(
+                    "Install it with {} or by adding it to your $PATH",
+                    format!("`apibara plugins install sink {}`", sink_type).green()
+                );
+                std::process::exit(1);
+            }
+            Err(err.into())
+        }
+    }
+}
+
+fn get_sink_command(sink_type: &str) -> String {
+    let dir = plugins_dir();
+    let binary = format!("apibara-sink-{}", sink_type);
+
+    // If the user hasn't installed the plugin, try to invoke from path.
+    let installed = dir.join(&binary);
+    if installed.exists() {
+        return installed.to_string_lossy().to_string();
+    } else {
+        binary
+    }
+}


### PR DESCRIPTION
**Summary**

The plugin manager is used to install, list, update, and remove plugins. At the moment, the only plugin type is `sink`.

The manager only supports installing plugins from a local file.