### PR TITLE
installer: use macos as the name of desktop darwin

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -89,7 +89,7 @@ get_arch() {
             _ostype=linux
             ;;
         Darwin)
-            _ostype=darwin
+            _ostype=macos
             ;;
         *)
             err "unrecognized OS type: $_ostype"


### PR DESCRIPTION
**Summary**

While `darwin` seems to be popular, `macos` is the name used by Rust and so it's easier to use that name.