### PR TITLE
sink: normalize sink logs

### DIFF
--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -209,12 +209,9 @@ let
   */
   agents = {
     x86_64-linux = {
-      os = "linux";
-      arch = "x86_64";
+      queue = "default";
     };
     aarch64-linux = {
-      os = "linux";
-      arch = "aarch64";
       queue = "aarch64-linux";
     };
   };
@@ -234,9 +231,6 @@ let
         {
           label = ":nix: Checks";
           command = "nix flake check";
-        }
-        {
-          wait = { };
         }
         {
           label = ":rust: Build tests";

--- a/sink-mongo/src/sink.rs
+++ b/sink-mongo/src/sink.rs
@@ -52,7 +52,7 @@ impl Sink for MongoSink {
     type Error = SinkMongoError;
 
     async fn from_options(options: Self::Options) -> Result<Self, Self::Error> {
-        info!("mongo: connecting to database");
+        info!("connecting to database");
         let connection_string = options
             .connection_string
             .ok_or(Self::Error::MissingConnectionString)?;
@@ -110,7 +110,7 @@ impl Sink for MongoSink {
     }
 
     async fn handle_invalidate(&mut self, cursor: &Option<Cursor>) -> Result<(), Self::Error> {
-        info!(cursor = %DisplayCursor(cursor), "mongo: handling invalidate");
+        info!(cursor = %DisplayCursor(cursor), "handling invalidate");
 
         let mut session = self.client.start_session(None).await?;
 

--- a/sink-parquet/src/sink.rs
+++ b/sink-parquet/src/sink.rs
@@ -99,7 +99,6 @@ impl Sink for ParquetSink {
         };
 
         if batch.is_empty() {
-            warn!("data is empty, skipping");
             // Skip persistence in case the buffer is still not flushed
             return Ok(CursorAction::Skip);
         }

--- a/sink-postgres/src/sink.rs
+++ b/sink-postgres/src/sink.rs
@@ -31,7 +31,7 @@ impl Sink for PostgresSink {
     type Error = SinkPostgresError;
 
     async fn from_options(options: Self::Options) -> Result<Self, Self::Error> {
-        info!("postgres: connecting to database");
+        info!("connecting to database");
         let config = options.to_postgres_configuration()?;
         let table_name = config.table_name;
 
@@ -39,7 +39,7 @@ impl Sink for PostgresSink {
         let (client, connection) = config.pg.connect(NoTls).await?;
         tokio::spawn(connection);
 
-        info!("postgres: client connected successfully");
+        info!("client connected successfully");
 
         let query = format!(
             "INSERT INTO {} SELECT * FROM json_populate_recordset(NULL::{}, $1::json)",
@@ -71,7 +71,7 @@ impl Sink for PostgresSink {
             cursor = %DisplayCursor(cursor),
             end_cursor = %end_cursor,
             finality = ?finality,
-            "postgres: handling data"
+            "handling data"
         );
 
         let Some(batch) = batch.as_array_of_objects() else {
@@ -80,7 +80,6 @@ impl Sink for PostgresSink {
         };
 
         if batch.is_empty() {
-            warn!("data is empty, skipping");
             return Ok(CursorAction::Persist);
         }
 
@@ -102,7 +101,7 @@ impl Sink for PostgresSink {
     }
 
     async fn handle_invalidate(&mut self, cursor: &Option<Cursor>) -> Result<(), Self::Error> {
-        info!(cursor = %DisplayCursor(cursor), "postgres: handling invalidate");
+        info!(cursor = %DisplayCursor(cursor), "handling invalidate");
 
         if let Some(cursor) = cursor {
             // convert to i64 because that's the tokio_postgres type that maps to bigint

--- a/sink-webhook/src/sink.rs
+++ b/sink-webhook/src/sink.rs
@@ -1,5 +1,5 @@
 use apibara_core::node::v1alpha2::{Cursor, DataFinality};
-use apibara_sink_common::{CursorAction, LoadScriptError, Sink};
+use apibara_sink_common::{CursorAction, DisplayCursor, LoadScriptError, Sink};
 use async_trait::async_trait;
 use http::{
     header::{InvalidHeaderName, InvalidHeaderValue},
@@ -97,16 +97,11 @@ impl Sink for WebhookSink {
         finality: &DataFinality,
         batch: &Value,
     ) -> Result<CursorAction, Self::Error> {
-        let cursor_str = cursor
-            .clone()
-            .map(|c| c.to_string())
-            .unwrap_or("genesis".into());
-
         info!(
-            cursor = %cursor_str,
+            cursor = %DisplayCursor(cursor),
             end_block = %end_cursor,
             finality = ?finality,
-            "webhook: calling with data"
+            "calling with data"
         );
 
         if self.raw {
@@ -145,7 +140,7 @@ impl Sink for WebhookSink {
             .map(|c| c.to_string())
             .unwrap_or("genesis".into());
 
-        info!(cursor = %cursor_str, "webhook: calling with invalidate");
+        info!(cursor = %cursor_str, "calling with invalidate");
         let body = json!({
             "invalidate": {
                 "cursor": cursor,


### PR DESCRIPTION
**Summary**

Change the sink logs to have somewhat the same output. Remove warning logs if the user passes an empty array since this is normal in practice.