### PR TITLE
release: cli, sink-console, sink-mongo, sink-parquet, sink-postgres, sink-webhook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "apibara-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "apibara-observability",
  "apibara-sink-common",
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-console"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-mongo"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-parquet"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-postgres"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -484,7 +484,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-webhook"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "apibara-core",
  "apibara-observability",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,10 +6,23 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2023-09-16
+
+_Introduce sink status gRPC service._
+
+### Changed
+
+ - The status server is now a gRPC service. This service returns the sink
+   indexing status, the starting block, and the chain's current head block
+   from the upstream DNA service. 
+ - The status server now binds on a random port. This means it's easier to run
+   multiple sinks at the same time.
+
 ## [0.1.0] - 2023-08-08
 
 _First tagged release 🎉_
 
 
+[0.2.0]: https://github.com/apibara/dna/releases/tag/cli/v0.2.0
 [0.1.0]: https://github.com/apibara/dna/releases/tag/cli/v0.1.0
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-cli"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 

--- a/sink-console/CHANGELOG.md
+++ b/sink-console/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2023-09-16
+
+_Introduce sink status gRPC service._
+
+### Changed
+
+ - The status server is now a gRPC service. This service returns the sink
+   indexing status, the starting block, and the chain's current head block
+   from the upstream DNA service. 
+ - The status server now binds on a random port. This means it's easier to run
+   multiple sinks at the same time.
+
 ## [0.2.0] - 2023-08-21
 
 _This release improves the developer experience when running locally._
@@ -28,5 +40,6 @@ _This release improves the developer experience when running locally._
 _First tagged release 🎉_
 
 
+[0.3.0]: https://github.com/apibara/dna/releases/tag/sink-console/v0.3.0
 [0.2.0]: https://github.com/apibara/dna/releases/tag/sink-console/v0.2.0
 [0.1.0]: https://github.com/apibara/dna/releases/tag/sink-console/v0.1.0

--- a/sink-console/Cargo.toml
+++ b/sink-console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-console"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sink-mongo/CHANGELOG.md
+++ b/sink-mongo/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2023-09-16
+
+_Introduce sink status gRPC service._
+
+### Changed
+
+ - The status server is now a gRPC service. This service returns the sink
+   indexing status, the starting block, and the chain's current head block
+   from the upstream DNA service. 
+ - The status server now binds on a random port. This means it's easier to run
+   multiple sinks at the same time.
+
+
 ## [0.3.0] - 2023-08-29
 
 _Introduce entity mode to index stateful entities._
@@ -43,6 +56,7 @@ _This release improves the developer experience when running locally._
 _First tagged release 🎉_
 
 
+[0.4.0]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.4.0
 [0.3.0]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.3.0
 [0.2.0]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.2.0
 [0.1.0]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.1.0

--- a/sink-mongo/Cargo.toml
+++ b/sink-mongo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-mongo"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sink-parquet/CHANGELOG.md
+++ b/sink-parquet/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2023-09-16
+
+_Introduce sink status gRPC service._
+
+### Changed
+
+ - The status server is now a gRPC service. This service returns the sink
+   indexing status, the starting block, and the chain's current head block
+   from the upstream DNA service. 
+ - The status server now binds on a random port. This means it's easier to run
+   multiple sinks at the same time.
+
 ## [0.2.0] - 2023-08-21
 
 _This release improves the developer experience when running locally._
@@ -28,5 +40,6 @@ _This release improves the developer experience when running locally._
 _First tagged release 🎉_
 
 
+[0.3.0]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.3.0
 [0.2.0]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.2.0
 [0.1.0]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.1.0

--- a/sink-parquet/Cargo.toml
+++ b/sink-parquet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-parquet"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sink-postgres/CHANGELOG.md
+++ b/sink-postgres/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2023-09-16
+
+_Introduce sink status gRPC service._
+
+### Changed
+
+ - The status server is now a gRPC service. This service returns the sink
+   indexing status, the starting block, and the chain's current head block
+   from the upstream DNA service. 
+ - The status server now binds on a random port. This means it's easier to run
+   multiple sinks at the same time.
+
 ## [0.3.0] - 2023-09-11
 
 _Bring support for TLS connections._
@@ -47,6 +59,7 @@ _This release improves the developer experience when running locally._
 _First tagged release 🎉_
 
 
+[0.4.0]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.4.0
 [0.3.0]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.3.0
 [0.2.0]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.2.0
 [0.1.0]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.1.0

--- a/sink-postgres/Cargo.toml
+++ b/sink-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-postgres"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sink-webhook/CHANGELOG.md
+++ b/sink-webhook/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2023-09-16
+
+_Introduce sink status gRPC service._
+
+### Changed
+
+ - The status server is now a gRPC service. This service returns the sink
+   indexing status, the starting block, and the chain's current head block
+   from the upstream DNA service. 
+ - The status server now binds on a random port. This means it's easier to run
+   multiple sinks at the same time.
+
 ## [0.2.0] - 2023-08-21
 
 _This release improves the developer experience when running locally._
@@ -31,5 +43,6 @@ _This release improves the developer experience when running locally._
 _First tagged release 🎉_
 
 
+[0.3.0]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.3.0
 [0.2.0]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.2.0
 [0.1.0]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.1.0

--- a/sink-webhook/Cargo.toml
+++ b/sink-webhook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-webhook"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION

**Summary**

cli: v0.2.0
sink-console: v0.3.0
sink-mongo: v0.4.0
sink-parquet: v0.3.0
sink-postgres: v0.4.0
sink-webhook: v0.3.0