### PR TITLE
Add timeout waiting for stream messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,7 +392,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-console"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-mongo"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-parquet"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-postgres"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-webhook"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "apibara-core",
  "apibara-observability",

--- a/sink-console/CHANGELOG.md
+++ b/sink-console/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2023-10-11
+
+_Disconnect when stream hangs._
+
+### Added
+
+ - Add a new `--timeout-duration-seconds` flag to control the timeout between
+   stream messages. If the stream doesn't receive any message in this interval,
+   the sink exits. Defaults to 45 seconds.
+
+
 ## [0.3.0] - 2023-09-16
 
 _Introduce sink status gRPC service._
@@ -40,6 +51,7 @@ _This release improves the developer experience when running locally._
 _First tagged release 🎉_
 
 
+[0.3.1]: https://github.com/apibara/dna/releases/tag/sink-console/v0.3.1
 [0.3.0]: https://github.com/apibara/dna/releases/tag/sink-console/v0.3.0
 [0.2.0]: https://github.com/apibara/dna/releases/tag/sink-console/v0.2.0
 [0.1.0]: https://github.com/apibara/dna/releases/tag/sink-console/v0.1.0

--- a/sink-console/Cargo.toml
+++ b/sink-console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-console"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sink-mongo/CHANGELOG.md
+++ b/sink-mongo/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2023-10-11
+
+_Disconnect when stream hangs._
+
+### Added
+
+ - Add a new `--timeout-duration-seconds` flag to control the timeout between
+   stream messages. If the stream doesn't receive any message in this interval,
+   the sink exits. Defaults to 45 seconds.
+
+
 ## [0.4.0] - 2023-09-16
 
 _Introduce sink status gRPC service._
@@ -56,6 +67,7 @@ _This release improves the developer experience when running locally._
 _First tagged release 🎉_
 
 
+[0.4.1]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.4.1
 [0.4.0]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.4.0
 [0.3.0]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.3.0
 [0.2.0]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.2.0

--- a/sink-mongo/Cargo.toml
+++ b/sink-mongo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-mongo"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sink-parquet/CHANGELOG.md
+++ b/sink-parquet/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2023-10-11
+
+_Disconnect when stream hangs._
+
+### Added
+
+ - Add a new `--timeout-duration-seconds` flag to control the timeout between
+   stream messages. If the stream doesn't receive any message in this interval,
+   the sink exits. Defaults to 45 seconds.
+
+
 ## [0.3.0] - 2023-09-16
 
 _Introduce sink status gRPC service._
@@ -40,6 +51,7 @@ _This release improves the developer experience when running locally._
 _First tagged release 🎉_
 
 
+[0.3.1]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.3.1
 [0.3.0]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.3.0
 [0.2.0]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.2.0
 [0.1.0]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.1.0

--- a/sink-parquet/Cargo.toml
+++ b/sink-parquet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-parquet"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sink-postgres/CHANGELOG.md
+++ b/sink-postgres/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2023-10-11
+
+_Disconnect when stream hangs._
+
+### Added
+
+ - Add a new `--timeout-duration-seconds` flag to control the timeout between
+   stream messages. If the stream doesn't receive any message in this interval,
+   the sink exits. Defaults to 45 seconds.
+
+
 ## [0.4.0] - 2023-09-16
 
 _Introduce sink status gRPC service._
@@ -59,6 +70,7 @@ _This release improves the developer experience when running locally._
 _First tagged release 🎉_
 
 
+[0.4.1]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.4.1
 [0.4.0]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.4.0
 [0.3.0]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.3.0
 [0.2.0]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.2.0

--- a/sink-postgres/Cargo.toml
+++ b/sink-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-postgres"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sink-webhook/CHANGELOG.md
+++ b/sink-webhook/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2023-10-11
+
+_Disconnect when stream hangs._
+
+### Added
+
+ - Add a new `--timeout-duration-seconds` flag to control the timeout between
+   stream messages. If the stream doesn't receive any message in this interval,
+   the sink exits. Defaults to 45 seconds.
+
+
 ## [0.3.0] - 2023-09-16
 
 _Introduce sink status gRPC service._
@@ -43,6 +54,7 @@ _This release improves the developer experience when running locally._
 _First tagged release 🎉_
 
 
+[0.3.1]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.3.1
 [0.3.0]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.3.0
 [0.2.0]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.2.0
 [0.1.0]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.1.0

--- a/sink-webhook/Cargo.toml
+++ b/sink-webhook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-webhook"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
**Summary**

gRPC streams can hang without either side being notified. The DNA protocol
includes heartbeat messages to help detect this, but until now the sinks were
not taking advantage of this behaviour.

This commit stops the sink if it doesn't receive any message for a given amount of seconds.