### PR TITLE
sdk: provide sensible stream timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "apibara-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "apibara-core",
  "apibara-observability",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2023-10-17
+
+_Minor bug fixes in the `apibara test` command._
+
+### Fixed
+
+ - Avoid storing sensitive information such as authentication tokens in the
+   test snapshots.
+
 ## [0.3.0] - 2023-09-26
 
 _Add the `apibara test` command._
@@ -39,6 +48,7 @@ _Introduce sink status gRPC service._
 _First tagged release 🎉_
 
 
+[0.3.1]: https://github.com/apibara/dna/releases/tag/cli/v0.3.1
 [0.3.0]: https://github.com/apibara/dna/releases/tag/cli/v0.3.0
 [0.2.0]: https://github.com/apibara/dna/releases/tag/cli/v0.2.0
 [0.1.0]: https://github.com/apibara/dna/releases/tag/cli/v0.1.0

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-cli"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 license.workspace = true
 

--- a/cli/src/test/snapshot.rs
+++ b/cli/src/test/snapshot.rs
@@ -149,12 +149,26 @@ impl SnapshotGenerator {
             return Err(eyre!("Empty snapshot, no data found for the selected options (filter, starting_block, num_batches ...)"));
         }
 
+        let stream_options = sanitize_stream_options(&self.stream_options);
+
         Ok(Snapshot {
             script_path: self.script_path,
             num_batches: self.num_batches,
-            stream_options: self.stream_options,
+            stream_options,
             stream_configuration_options: self.stream_configuration_options,
             stream,
         })
+    }
+}
+
+/// Remove all the fields from the stream options that are not needed for the snapshot.
+///
+/// This is done to avoid leaking sensitive information (e.g. the bearer token) in the snapshots.
+fn sanitize_stream_options(options: &StreamOptions) -> StreamOptions {
+    StreamOptions {
+        stream_url: options.stream_url.clone(),
+        max_message_size: options.max_message_size.clone(),
+        timeout_duration_seconds: options.timeout_duration_seconds,
+        ..Default::default()
     }
 }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -74,7 +74,6 @@ pub struct StreamClient {
 /// Data stream builder.
 ///
 /// This struct is used to configure and connect to an Apibara data stream.
-#[derive(Default)]
 pub struct ClientBuilder {
     token: Option<String>,
     max_message_size: Option<usize>,
@@ -145,6 +144,17 @@ impl ClientBuilder {
             inner: default_client,
             timeout: self.timeout,
         })
+    }
+}
+
+impl Default for ClientBuilder {
+    fn default() -> Self {
+        ClientBuilder {
+            token: None,
+            max_message_size: None,
+            metadata: MetadataMap::default(),
+            timeout: Duration::from_secs(45),
+        }
     }
 }
 

--- a/sink-common/src/configuration.rs
+++ b/sink-common/src/configuration.rs
@@ -81,19 +81,24 @@ pub struct DotenvOptions {
 pub struct StreamOptions {
     /// DNA stream url. If starting with `https://`, use a secure connection.
     #[arg(long, env)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stream_url: Option<String>,
     /// Limits the maximum size of a decoded message. Accept message size in human readable form,
     /// e.g. 1kb, 1MB, 1GB. If not set the default is 1MB.
     #[arg(long, env)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_message_size: Option<String>,
     /// Add metadata to the stream, in the `key: value` format. Can be specified multiple times.
     #[arg(long, short = 'M', env, value_delimiter = ',')]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Vec<String>>,
     /// Use the authorization together when connecting to the stream.
     #[arg(long, short = 'A', env)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub auth_token: Option<String>,
     /// Maximum timeout (in seconds) between stream messages. Defaults to 45s.
     #[arg(long, env)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout_duration_seconds: Option<u64>,
 }
 
@@ -104,10 +109,13 @@ pub struct StreamConfigurationOptions {
     #[serde(flatten)]
     pub filter: NetworkFilterOptions,
     /// Set the response preferred batch size.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub batch_size: Option<u64>,
     /// The finality of the data to be streamed.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub finality: Option<DataFinality>,
     /// Start streaming data from the specified block.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub starting_block: Option<u64>,
 }
 

--- a/sink-common/src/configuration.rs
+++ b/sink-common/src/configuration.rs
@@ -178,9 +178,7 @@ impl StreamOptions {
             .map_err(StreamOptionsError::MessageSize)?
             .unwrap_or(ByteSize::mb(100));
 
-        let timeout_duration = Duration::from_secs(
-            self.timeout_duration_seconds.unwrap_or(45)
-        );
+        let timeout_duration = Duration::from_secs(self.timeout_duration_seconds.unwrap_or(45));
 
         let mut metadata = MetadataMap::new();
         for entry in self.metadata.unwrap_or_default() {


### PR DESCRIPTION
**Summary**

The default stream timeout was 0 seconds, which resulted in the stream being unusable. We change the default timeout to be 45 seconds.