### PR TITLE
release: sink-console, sink-mongo, sink-parquet, sink-postgres, sink-webhook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-console"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-mongo"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-parquet"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-postgres"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -497,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-webhook"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "apibara-core",
  "apibara-observability",

--- a/sinks/sink-console/CHANGELOG.md
+++ b/sinks/sink-console/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.5] - 2023-11-11
+
+_Fix an issue on Linux._
+
+### Fixed
+
+ - Link against GLIBC 3.5. The most recent build was linking against GLIBC 3.8
+   which caused some issues on non-rolling release distributions.
+
 ## [0.3.4] - 2023-11-07
 
 _Improve performance for data-heavy indexers._ 
@@ -94,6 +103,7 @@ _This release improves the developer experience when running locally._
 _First tagged release 🎉_
 
 
+[0.3.5]: https://github.com/apibara/dna/releases/tag/sink-console/v0.3.5
 [0.3.4]: https://github.com/apibara/dna/releases/tag/sink-console/v0.3.4
 [0.3.3]: https://github.com/apibara/dna/releases/tag/sink-console/v0.3.3
 [0.3.2]: https://github.com/apibara/dna/releases/tag/sink-console/v0.3.2

--- a/sinks/sink-console/Cargo.toml
+++ b/sinks/sink-console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-console"
-version = "0.3.4"
+version = "0.3.5"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-mongo/CHANGELOG.md
+++ b/sinks/sink-mongo/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.6] - 2023-11-11
+
+_Fix an issue on Linux._
+
+### Fixed
+
+ - Link against GLIBC 3.5. The most recent build was linking against GLIBC 3.8
+   which caused some issues on non-rolling release distributions.
+
 ## [0.4.5] - 2023-11-09
 
 _Write to the same collection from multiple indexers._
@@ -121,6 +130,8 @@ _This release improves the developer experience when running locally._
 _First tagged release 🎉_
 
 
+[0.4.6]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.4.6
+[0.4.5]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.4.5
 [0.4.4]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.4.4
 [0.4.3]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.4.3
 [0.4.2]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.4.2

--- a/sinks/sink-mongo/Cargo.toml
+++ b/sinks/sink-mongo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-mongo"
-version = "0.4.5"
+version = "0.4.6"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-parquet/CHANGELOG.md
+++ b/sinks/sink-parquet/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.5] - 2023-11-11
+
+_Fix an issue on Linux._
+
+### Fixed
+
+ - Link against GLIBC 3.5. The most recent build was linking against GLIBC 3.8
+   which caused some issues on non-rolling release distributions.
+
 ## [0.3.4] - 2023-11-07
 
 _Improve performance for data-heavy indexers._ 
@@ -94,6 +103,7 @@ _This release improves the developer experience when running locally._
 _First tagged release 🎉_
 
 
+[0.3.5]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.3.5
 [0.3.4]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.3.4
 [0.3.3]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.3.3
 [0.3.2]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.3.2

--- a/sinks/sink-parquet/Cargo.toml
+++ b/sinks/sink-parquet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-parquet"
-version = "0.3.4"
+version = "0.3.5"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-postgres/CHANGELOG.md
+++ b/sinks/sink-postgres/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.6] - 2023-11-11
+
+_Fix an issue on Linux._
+
+### Fixed
+
+ - Link against GLIBC 3.5. The most recent build was linking against GLIBC 3.8
+   which caused some issues on non-rolling release distributions.
+
 ## [0.4.5] - 2023-11-07
 
 _Improve performance for data-heavy indexers._ 
@@ -124,6 +133,7 @@ _This release improves the developer experience when running locally._
 _First tagged release 🎉_
 
 
+[0.4.6]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.4.6
 [0.4.5]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.4.5
 [0.4.4]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.4.4
 [0.4.3]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.4.3

--- a/sinks/sink-postgres/Cargo.toml
+++ b/sinks/sink-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-postgres"
-version = "0.4.5"
+version = "0.4.6"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-webhook/CHANGELOG.md
+++ b/sinks/sink-webhook/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.5] - 2023-11-11
+
+_Fix an issue on Linux._
+
+### Fixed
+
+ - Link against GLIBC 3.5. The most recent build was linking against GLIBC 3.8
+   which caused some issues on non-rolling release distributions.
+
 ## [0.3.4] - 2023-11-07
 
 _Improve performance for data-heavy indexers._ 
@@ -97,6 +106,7 @@ _This release improves the developer experience when running locally._
 _First tagged release 🎉_
 
 
+[0.3.5]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.3.5
 [0.3.4]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.3.4
 [0.3.3]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.3.3
 [0.3.2]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.3.2

--- a/sinks/sink-webhook/Cargo.toml
+++ b/sinks/sink-webhook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-webhook"
-version = "0.3.4"
+version = "0.3.5"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
**Summary**

sink-console: v0.3.5
sink-mongo: v0.4.6
sink-parquet: v0.3.5
sink-postgres: v0.4.6
sink-webhook: v0.3.5