### PR TITLE
sink: allow access to parent's environment variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-console"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -417,7 +417,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-mongo"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-parquet"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -479,7 +479,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-postgres"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-webhook"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "apibara-core",
  "apibara-observability",

--- a/sinks/sink-common/src/configuration.rs
+++ b/sinks/sink-common/src/configuration.rs
@@ -72,6 +72,9 @@ pub struct DotenvOptions {
     /// only from the ones specified in this file.
     #[arg(long, env)]
     pub allow_env: Option<PathBuf>,
+    /// Grant access to the specified environment variables.
+    #[arg(long, env, value_delimiter = ',')]
+    pub allow_env_from_env: Option<Vec<String>>,
 }
 
 #[derive(Args, Debug, Default, Serialize, Deserialize, Clone)]

--- a/sinks/sink-console/CHANGELOG.md
+++ b/sinks/sink-console/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.6] - 2023-11-16
+
+_Add new environment-related options._
+
+### Added
+
+ - Add new `--allow-env-from-env` flag to allow the indexer script to access
+ the parent process environment variables. Users can pass a list of
+ comma-separated variables to this option.
+
+### Changed
+
+ - Cleanup the default logs to only show the current block number.
+ - To restore the previous, more detailed logs, set the log level to debug.
+
 ## [0.3.5] - 2023-11-11
 
 _Fix an issue on Linux._
@@ -103,6 +118,7 @@ _This release improves the developer experience when running locally._
 _First tagged release 🎉_
 
 
+[0.3.6]: https://github.com/apibara/dna/releases/tag/sink-console/v0.3.6
 [0.3.5]: https://github.com/apibara/dna/releases/tag/sink-console/v0.3.5
 [0.3.4]: https://github.com/apibara/dna/releases/tag/sink-console/v0.3.4
 [0.3.3]: https://github.com/apibara/dna/releases/tag/sink-console/v0.3.3

--- a/sinks/sink-console/Cargo.toml
+++ b/sinks/sink-console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-console"
-version = "0.3.5"
+version = "0.3.6"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-mongo/CHANGELOG.md
+++ b/sinks/sink-mongo/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.7] - 2023-11-16
+
+_Add new environment-related options._
+
+### Added
+
+ - Add new `--allow-env-from-env` flag to allow the indexer script to access
+ the parent process environment variables. Users can pass a list of
+ comma-separated variables to this option.
+
+### Changed
+
+ - Cleanup the default logs to only show the current block number.
+ - To restore the previous, more detailed logs, set the log level to debug.
+
 ## [0.4.6] - 2023-11-11
 
 _Fix an issue on Linux._
@@ -130,6 +145,7 @@ _This release improves the developer experience when running locally._
 _First tagged release 🎉_
 
 
+[0.4.7]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.4.7
 [0.4.6]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.4.6
 [0.4.5]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.4.5
 [0.4.4]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.4.4

--- a/sinks/sink-mongo/Cargo.toml
+++ b/sinks/sink-mongo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-mongo"
-version = "0.4.6"
+version = "0.4.7"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-parquet/CHANGELOG.md
+++ b/sinks/sink-parquet/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.6] - 2023-11-16
+
+_Add new environment-related options._
+
+### Added
+
+ - Add new `--allow-env-from-env` flag to allow the indexer script to access
+ the parent process environment variables. Users can pass a list of
+ comma-separated variables to this option.
+
+### Changed
+
+ - Cleanup the default logs to only show the current block number.
+ - To restore the previous, more detailed logs, set the log level to debug.
+
 ## [0.3.5] - 2023-11-11
 
 _Fix an issue on Linux._
@@ -103,6 +118,7 @@ _This release improves the developer experience when running locally._
 _First tagged release 🎉_
 
 
+[0.3.6]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.3.6
 [0.3.5]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.3.5
 [0.3.4]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.3.4
 [0.3.3]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.3.3

--- a/sinks/sink-parquet/Cargo.toml
+++ b/sinks/sink-parquet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-parquet"
-version = "0.3.5"
+version = "0.3.6"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-postgres/CHANGELOG.md
+++ b/sinks/sink-postgres/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.7] - 2023-11-16
+
+_Add new environment-related options._
+
+### Added
+
+ - Add new `--allow-env-from-env` flag to allow the indexer script to access
+ the parent process environment variables. Users can pass a list of
+ comma-separated variables to this option.
+
+### Changed
+
+ - Cleanup the default logs to only show the current block number.
+ - To restore the previous, more detailed logs, set the log level to debug.
+
 ## [0.4.6] - 2023-11-11
 
 _Fix an issue on Linux._
@@ -133,6 +148,7 @@ _This release improves the developer experience when running locally._
 _First tagged release 🎉_
 
 
+[0.4.7]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.4.7
 [0.4.6]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.4.6
 [0.4.5]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.4.5
 [0.4.4]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.4.4

--- a/sinks/sink-postgres/Cargo.toml
+++ b/sinks/sink-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-postgres"
-version = "0.4.6"
+version = "0.4.7"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-webhook/CHANGELOG.md
+++ b/sinks/sink-webhook/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.6] - 2023-11-16
+
+_Add new environment-related options._
+
+### Added
+
+ - Add new `--allow-env-from-env` flag to allow the indexer script to access
+ the parent process environment variables. Users can pass a list of
+ comma-separated variables to this option.
+
+### Changed
+
+ - Cleanup the default logs to only show the current block number.
+ - To restore the previous, more detailed logs, set the log level to debug.
+
 ## [0.3.5] - 2023-11-11
 
 _Fix an issue on Linux._
@@ -106,6 +121,7 @@ _This release improves the developer experience when running locally._
 _First tagged release 🎉_
 
 
+[0.3.6]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.3.6
 [0.3.5]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.3.5
 [0.3.4]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.3.4
 [0.3.3]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.3.3

--- a/sinks/sink-webhook/Cargo.toml
+++ b/sinks/sink-webhook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-webhook"
-version = "0.3.5"
+version = "0.3.6"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
**Summary**
In some cases (e.g. Kubernetes), it's infeasible to allow access only to environment variables specified in a .env file.
This commit adds a new flag to allow access to the parent process environment variables.