### PR TITLE
Support writing to multiple collections in mongo

### DIFF
--- a/sinks/sink-mongo/src/configuration.rs
+++ b/sinks/sink-mongo/src/configuration.rs
@@ -13,8 +13,14 @@ pub struct SinkMongoOptions {
     #[arg(long, env = "MONGO_DATABASE")]
     pub database: Option<String>,
     /// The collection where to store the data.
-    #[arg(long, env = "MONGO_COLLECTION_NAME")]
+    #[arg(
+        long,
+        env = "MONGO_COLLECTION_NAME",
+        conflicts_with = "collection_names"
+    )]
     pub collection_name: Option<String>,
+    #[arg(long, env = "MONGO_COLLECTION_NAMES", value_delimiter = ',')]
+    pub collection_names: Option<Vec<String>>,
     /// Enable storing records as entities.
     pub entity_mode: Option<bool>,
     #[clap(skip)]
@@ -27,6 +33,7 @@ impl SinkOptions for SinkMongoOptions {
             connection_string: self.connection_string.or(other.connection_string),
             database: self.database.or(other.database),
             collection_name: self.collection_name.or(other.collection_name),
+            collection_names: self.collection_names.or(other.collection_names),
             entity_mode: self.entity_mode.or(other.entity_mode),
             invalidate: self.invalidate.or(other.invalidate),
         }

--- a/sinks/sink-mongo/src/sink.rs
+++ b/sinks/sink-mongo/src/sink.rs
@@ -7,6 +7,7 @@ use error_stack::{Result, ResultExt};
 use futures_util::TryStreamExt;
 use mongodb::bson::{doc, to_document, Bson, Document};
 use mongodb::ClientSession;
+use std::collections::HashMap;
 
 use mongodb::options::{UpdateModifications, UpdateOptions};
 use mongodb::{options::ClientOptions, Client, Collection};
@@ -27,7 +28,7 @@ impl fmt::Display for SinkMongoError {
 }
 
 pub struct MongoSink {
-    pub collection: Collection<Document>,
+    pub collections: HashMap<String, Collection<Document>>,
     invalidate: Option<Document>,
     client: Client,
     mode: Mode,
@@ -55,10 +56,18 @@ impl Sink for MongoSink {
             .database
             .ok_or(SinkMongoError)
             .attach_printable("missing database name")?;
-        let collection_name = options
+
+        if options.collection_name.is_some() && options.collection_names.is_some() {
+            return Err(SinkMongoError)
+                .attach_printable("conflicting collection_name and collection_names options");
+        }
+        let collection_names = options
             .collection_name
+            .map(|c| vec![c])
+            .or(options.collection_names)
+            .and_then(|vec| (!vec.is_empty()).then_some(vec))
             .ok_or(SinkMongoError)
-            .attach_printable("missing collection name")?;
+            .attach_printable("missing collection name or collection names")?;
 
         let client_options = ClientOptions::parse(connection_string)
             .await
@@ -69,7 +78,10 @@ impl Sink for MongoSink {
             .change_context(SinkMongoError)
             .attach_printable("failed to create mongo client")?;
         let db = client.database(&db_name);
-        let collection = db.collection::<Document>(&collection_name);
+        let collections: HashMap<String, Collection<Document>> = collection_names
+            .into_iter()
+            .map(|c| (c.clone(), db.collection::<Document>(&c)))
+            .collect();
 
         let entity_mode = options.entity_mode.unwrap_or(false);
         let mode = if entity_mode {
@@ -79,7 +91,7 @@ impl Sink for MongoSink {
         };
 
         Ok(Self {
-            collection,
+            collections,
             client,
             mode,
             invalidate: options.invalidate,
@@ -100,6 +112,16 @@ impl Sink for MongoSink {
 
         if values.is_empty() {
             return Ok(CursorAction::Persist);
+        }
+
+        if self.collections.len() > 1 {
+            let missing_collection_key =
+                values.iter().any(|value| value.get("collection").is_none());
+
+            if missing_collection_key {
+                warn!("some documents missing 'collection' key while in multi collection mode");
+                return Ok(CursorAction::Persist);
+            }
         }
 
         self.insert_data(&ctx.end_cursor, values).await?;
@@ -136,33 +158,91 @@ impl Sink for MongoSink {
             unclamp_query.extend(invalidate.clone());
         }
 
-        self.collection
-            .delete_many_with_session(delete_query, None, &mut session)
-            .await
-            .change_context(SinkMongoError)
-            .attach_printable("failed to invalidate data (delete)")?;
-        self.collection
-            .update_many_with_session(unclamp_query, unset_cursor_to, None, &mut session)
-            .await
-            .change_context(SinkMongoError)
-            .attach_printable("failed to invalidate data (update)")?;
+        for collection in self.collections.values() {
+            collection
+                .delete_many_with_session(delete_query.clone(), None, &mut session)
+                .await
+                .change_context(SinkMongoError)
+                .attach_printable("failed to invalidate data (delete)")?;
+            collection
+                .update_many_with_session(
+                    unclamp_query.clone(),
+                    unset_cursor_to.clone(),
+                    None,
+                    &mut session,
+                )
+                .await
+                .change_context(SinkMongoError)
+                .attach_printable("failed to invalidate data (update)")?;
+        }
 
         Ok(())
     }
 }
 
 impl MongoSink {
+    pub fn get_collection(
+        &self,
+        collection_name: &str,
+    ) -> Result<&Collection<Document>, SinkMongoError> {
+        self.collections
+            .get(collection_name)
+            .ok_or(SinkMongoError)
+            .attach_printable(format!("collection '{collection_name}' not found"))
+    }
+
     pub async fn insert_data(
         &self,
         end_cursor: &Cursor,
         values: &[Value],
     ) -> Result<(), SinkMongoError> {
-        let docs = values
+        let mut docs = values
             .iter()
             .map(to_document)
             .collect::<std::result::Result<Vec<_>, _>>()
             .change_context(SinkMongoError)
             .attach_printable("failed to convert batch to mongo document")?;
+
+        let mut docs_map: HashMap<String, Vec<Document>> = HashMap::new();
+
+        if self.collections.len() > 1 {
+            for doc in docs.iter_mut() {
+                let collection_name = doc
+                    .remove("collection")
+                    .ok_or(SinkMongoError)
+                    .attach_printable("document missing collection key")?
+                    .as_str()
+                    .ok_or(SinkMongoError)
+                    .attach_printable("collection is not a string")?
+                    .to_string();
+
+                if let Mode::Logs = self.mode {
+                    *doc = doc
+                        .get("data")
+                        .ok_or(SinkMongoError)
+                        .attach_printable("document missing data key")?
+                        .as_document()
+                        .ok_or(SinkMongoError)
+                        .attach_printable("data is not a document")?
+                        .clone();
+                }
+
+                if !docs_map.contains_key(&collection_name) {
+                    docs_map.insert(collection_name.clone(), Vec::new());
+                }
+
+                // Safe unwrap because of the above if statement where we add the
+                // `collection_name` key if it doesn't exist
+                docs_map
+                    .get_mut(&collection_name)
+                    .unwrap()
+                    .push(doc.clone());
+            }
+        } else {
+            // Safe unwrap because we already made sure we have at least one collection
+            let collection_name = self.collections.values().next().unwrap().name().to_string();
+            docs_map.insert(collection_name, docs);
+        }
 
         let mut session = self
             .client
@@ -172,9 +252,12 @@ impl MongoSink {
             .attach_printable("failed to create mongo session")?;
 
         match &self.mode {
-            Mode::Logs => self.insert_logs_data(end_cursor, docs, &mut session).await,
+            Mode::Logs => {
+                self.insert_logs_data(end_cursor, docs_map, &mut session)
+                    .await
+            }
             Mode::Entity => {
-                self.insert_entities_data(end_cursor, docs, &mut session)
+                self.insert_entities_data(end_cursor, docs_map, &mut session)
                     .await
             }
         }
@@ -183,20 +266,21 @@ impl MongoSink {
     pub async fn insert_logs_data(
         &self,
         end_cursor: &Cursor,
-        mut docs: Vec<Document>,
+        docs_map: HashMap<String, Vec<Document>>,
         session: &mut ClientSession,
     ) -> Result<(), SinkMongoError> {
         let cursor = doc! {
             "from": end_cursor.order_key as i64,
         };
 
-        docs.iter_mut().for_each(|doc| doc.add_cursor(&cursor));
-
-        self.collection
-            .insert_many_with_session(docs, None, session)
-            .await
-            .change_context(SinkMongoError)
-            .attach_printable("failed to insert data (logs)")?;
+        for (collection_name, mut docs) in docs_map {
+            docs.iter_mut().for_each(|doc| doc.add_cursor(&cursor));
+            self.get_collection(&collection_name)?
+                .insert_many_with_session(docs, None, session)
+                .await
+                .change_context(SinkMongoError)
+                .attach_printable("failed to insert data (logs)")?;
+        }
 
         Ok(())
     }
@@ -204,134 +288,145 @@ impl MongoSink {
     pub async fn insert_entities_data(
         &self,
         end_cursor: &Cursor,
-        docs: Vec<Document>,
+        docs_map: HashMap<String, Vec<Document>>,
         session: &mut ClientSession,
     ) -> Result<(), SinkMongoError> {
         let new_cursor = doc! {
             "from": end_cursor.order_key as i64,
         };
 
-        let entities_with_updates = docs
-            .into_iter()
-            .map(|doc| {
-                let entity = doc
-                    .get("entity")
-                    .ok_or(SinkMongoError)
-                    .attach_printable("document missing entity key")?
-                    .as_document()
-                    .ok_or(SinkMongoError)
-                    .attach_printable("entity is not an object")?;
+        // TODO: use transactions for performance
+        // See https://www.mongodb.com/docs/upcoming/core/transactions/
 
-                let update = doc
-                    .get("update")
-                    .ok_or(SinkMongoError)
-                    .attach_printable("document missing update key")?;
+        for (collection_name, docs) in docs_map {
+            let entities_with_updates = docs
+                .into_iter()
+                .map(|doc| {
+                    let entity = doc
+                        .get("entity")
+                        .ok_or(SinkMongoError)
+                        .attach_printable("document missing entity key")?
+                        .as_document()
+                        .ok_or(SinkMongoError)
+                        .attach_printable("entity is not an object")?;
 
-                // Validate that the update is either an object or an array of objects (a
-                // pipeline), then
-                // - if it's a document, add the cursor to the $set stage (or insert a new $set
-                // stage if not present).
-                // - add a new stage to the pipeline that sets the cursor.
-                let update = match update {
-                    Bson::Document(update) => {
-                        let mut update = update.clone();
-                        match update.get_document_mut("$set") {
-                            Err(_) => {
-                                update.insert("$set", doc! { "_cursor": new_cursor.clone() });
+                    let update = doc
+                        .get("update")
+                        .ok_or(SinkMongoError)
+                        .attach_printable("document missing update key")?;
+
+                    // Validate that the update is either an object or an array of objects (a
+                    // pipeline), then
+                    // - if it's a document, add the cursor to the $set stage (or insert a new $set
+                    // stage if not present).
+                    // - add a new stage to the pipeline that sets the cursor.
+                    let update = match update {
+                        Bson::Document(update) => {
+                            let mut update = update.clone();
+                            match update.get_document_mut("$set") {
+                                Err(_) => {
+                                    update.insert("$set", doc! { "_cursor": new_cursor.clone() });
+                                }
+                                Ok(set) => {
+                                    set.insert("_cursor", new_cursor.clone());
+                                }
                             }
-                            Ok(set) => {
-                                set.insert("_cursor", new_cursor.clone());
-                            }
+                            UpdateModifications::Document(update)
                         }
-                        UpdateModifications::Document(update)
-                    }
-                    Bson::Array(pipeline) => {
-                        let mut pipeline = pipeline
-                            .iter()
-                            .map(|stage| {
-                                stage
-                                    .as_document()
-                                    .ok_or(SinkMongoError)
-                                    .attach_printable(
-                                        "update is expected to be a document or pipeline",
-                                    )
-                                    .map(|stage| stage.clone())
-                            })
-                            .collect::<Result<Vec<_>, SinkMongoError>>()?;
-                        pipeline.push(doc! { "$set": { "_cursor": new_cursor.clone() } });
-                        UpdateModifications::Pipeline(pipeline)
-                    }
-                    _ => {
-                        return Err(SinkMongoError)
-                            .attach_printable("update is expected to be a document or pipeline");
+                        Bson::Array(pipeline) => {
+                            let mut pipeline = pipeline
+                                .iter()
+                                .map(|stage| {
+                                    stage
+                                        .as_document()
+                                        .ok_or(SinkMongoError)
+                                        .attach_printable(
+                                            "update is expected to be a document or pipeline",
+                                        )
+                                        .map(|stage| stage.clone())
+                                })
+                                .collect::<Result<Vec<_>, SinkMongoError>>()?;
+                            pipeline.push(doc! { "$set": { "_cursor": new_cursor.clone() } });
+                            UpdateModifications::Pipeline(pipeline)
+                        }
+                        _ => {
+                            return Err(SinkMongoError).attach_printable(
+                                "update is expected to be a document or pipeline",
+                            );
+                        }
+                    };
+
+                    Ok((entity.clone(), update))
+                })
+                .collect::<Result<Vec<_>, SinkMongoError>>()?;
+
+            let entities_filter = entities_with_updates
+                .iter()
+                .map(|(entity, _)| entity)
+                .collect::<Vec<_>>();
+
+            // get previous entities values, if any
+            let existing_docs_query = doc! {
+                "$and": [
+                    doc! { "$or": entities_filter.clone() },
+                    doc! { "_cursor.to": Bson::Null },
+                ]
+            };
+
+            let mut existing_docs = self
+                .get_collection(&collection_name)?
+                .find_with_session(Some(existing_docs_query.clone()), None, session)
+                .await
+                .change_context(SinkMongoError)
+                .attach_printable("failed to find existing documents")?
+                .stream(session)
+                .try_collect::<Vec<_>>()
+                .await
+                .change_context(SinkMongoError)
+                .attach_printable("failed to fetch find results")?;
+
+            if !existing_docs.is_empty() {
+                // update validity of previous values
+                let clamp_cursor = doc! {
+                    "$set": {
+                        "_cursor.to": end_cursor.order_key as i64,
                     }
                 };
 
-                Ok((entity.clone(), update))
-            })
-            .collect::<Result<Vec<_>, SinkMongoError>>()?;
+                self.get_collection(&collection_name)?
+                    .update_many_with_session(existing_docs_query, clamp_cursor, None, session)
+                    .await
+                    .change_context(SinkMongoError)
+                    .attach_printable("failed to insert entities (update existing)")?;
 
-        let entities_filter = entities_with_updates
-            .iter()
-            .map(|(entity, _)| entity)
-            .collect::<Vec<_>>();
+                // duplicate existing rows so that the update operation has something to work on
+                existing_docs
+                    .iter_mut()
+                    .for_each(|doc| doc.replace_cursor(&new_cursor));
 
-        // get previous entities values, if any
-        let existing_docs_query = doc! {
-            "$and": [
-                doc! { "$or": entities_filter.clone() },
-                doc! { "_cursor.to": Bson::Null },
-            ]
-        };
+                self.get_collection(&collection_name)?
+                    .insert_many_with_session(existing_docs, None, session)
+                    .await
+                    .change_context(SinkMongoError)
+                    .attach_printable("failed to insert entities (insert copies)")?;
+            }
 
-        let mut existing_docs = self
-            .collection
-            .find_with_session(Some(existing_docs_query.clone()), None, session)
-            .await
-            .change_context(SinkMongoError)
-            .attach_printable("failed to find existing documents")?
-            .stream(session)
-            .try_collect::<Vec<_>>()
-            .await
-            .change_context(SinkMongoError)
-            .attach_printable("failed to fetch find results")?;
+            // update values as specified by user
+            let update_options = UpdateOptions::builder().upsert(true).build();
 
-        if !existing_docs.is_empty() {
-            // update validity of previous values
-            let clamp_cursor = doc! {
-                "$set": {
-                    "_cursor.to": end_cursor.order_key as i64,
-                }
-            };
-
-            self.collection
-                .update_many_with_session(existing_docs_query, clamp_cursor, None, session)
-                .await
-                .change_context(SinkMongoError)
-                .attach_printable("failed to insert entities (update existing)")?;
-
-            // duplicate existing rows so that the update operation has something to work on
-            existing_docs
-                .iter_mut()
-                .for_each(|doc| doc.replace_cursor(&new_cursor));
-
-            self.collection
-                .insert_many_with_session(existing_docs, None, session)
-                .await
-                .change_context(SinkMongoError)
-                .attach_printable("failed to insert entities (insert copies)")?;
-        }
-
-        // update values as specified by user
-        let update_options = UpdateOptions::builder().upsert(true).build();
-
-        for (mut doc_filter, update) in entities_with_updates {
-            doc_filter.insert("_cursor.to", Bson::Null);
-            self.collection
-                .update_many_with_session(doc_filter, update, Some(update_options.clone()), session)
-                .await
-                .change_context(SinkMongoError)
-                .attach_printable("failed to insert entities (update entities)")?;
+            for (mut doc_filter, update) in entities_with_updates {
+                doc_filter.insert("_cursor.to", Bson::Null);
+                self.get_collection(&collection_name)?
+                    .update_many_with_session(
+                        doc_filter,
+                        update,
+                        Some(update_options.clone()),
+                        session,
+                    )
+                    .await
+                    .change_context(SinkMongoError)
+                    .attach_printable("failed to insert entities (update entities)")?;
+            }
         }
 
         Ok(())

--- a/sinks/sink-mongo/tests/test_multi_collection.rs
+++ b/sinks/sink-mongo/tests/test_multi_collection.rs
@@ -23,11 +23,20 @@ fn new_cursor(order_key: u64) -> Cursor {
     }
 }
 
-fn new_batch(start_cursor: &Option<Cursor>, end_cursor: &Cursor) -> Value {
-    new_batch_with_extra(start_cursor, end_cursor, json!({}))
+fn new_batch(
+    start_cursor: &Option<Cursor>,
+    end_cursor: &Cursor,
+    collection_names: &[String],
+) -> Value {
+    new_batch_with_extra(start_cursor, end_cursor, json!({}), collection_names)
 }
 
-fn new_batch_with_extra(start_cursor: &Option<Cursor>, end_cursor: &Cursor, extra: Value) -> Value {
+fn new_batch_with_extra(
+    start_cursor: &Option<Cursor>,
+    end_cursor: &Cursor,
+    extra: Value,
+    collection_names: &[String],
+) -> Value {
     let mut batch = Vec::new();
 
     let start_block_num = match start_cursor {
@@ -37,17 +46,19 @@ fn new_batch_with_extra(start_cursor: &Option<Cursor>, end_cursor: &Cursor, extr
 
     let end_block_num = end_cursor.order_key;
 
-    for i in start_block_num..end_block_num {
-        let mut doc = json!({
-            "block_num": i,
-            "block_str": format!("block_{}", i),
-        });
+    for collection_name in collection_names {
+        for i in start_block_num..end_block_num {
+            let mut doc = json!({
+                "block_num": i,
+                "block_str": format!("block_{}", i),
+            });
 
-        doc.as_object_mut()
-            .unwrap()
-            .extend(extra.as_object().unwrap().clone().into_iter());
+            doc.as_object_mut()
+                .unwrap()
+                .extend(extra.as_object().unwrap().clone().into_iter());
 
-        batch.push(doc);
+            batch.push(json!({"data": doc, "collection": collection_name}));
+        }
     }
 
     json!(batch)
@@ -106,11 +117,12 @@ async fn test_handle_data() -> Result<(), SinkMongoError> {
     let mongo = docker.run(new_mongo_image());
     let port = mongo.get_host_port_ipv4(27017);
 
+    let collection_names = vec!["test1".into(), "test2".into()];
+
     let options = SinkMongoOptions {
         connection_string: Some(format!("mongodb://localhost:{}", port)),
         database: Some("test".into()),
-        collection_name: Some("test".into()),
-        collection_names: None,
+        collection_names: Some(collection_names.clone()),
         ..SinkMongoOptions::default()
     };
 
@@ -119,35 +131,88 @@ async fn test_handle_data() -> Result<(), SinkMongoError> {
     let batch_size = 2;
     let num_batches = 5;
 
-    let mut all_docs = vec![];
-
     for order_key in 0..num_batches {
         let cursor = Some(new_cursor(order_key * batch_size));
         let end_cursor = new_cursor((order_key + 1) * batch_size);
         let finality = DataFinality::DataStatusFinalized;
-        let batch = new_batch(&cursor, &end_cursor);
         let ctx = Context {
             cursor: cursor.clone(),
             end_cursor: end_cursor.clone(),
             finality,
         };
 
-        let action = sink.handle_data(&ctx, &batch).await?;
+        let batch = new_batch(&cursor, &end_cursor, &collection_names);
 
+        let action = sink.handle_data(&ctx, &batch).await?;
         assert_eq!(action, CursorAction::Persist);
 
-        all_docs.extend(new_docs(&cursor, &end_cursor));
-
         let action = sink.handle_data(&ctx, &new_not_array_of_objects()).await?;
-
         assert_eq!(action, CursorAction::Persist);
 
         let action = sink.handle_data(&ctx, &json!([])).await?;
-
         assert_eq!(action, CursorAction::Persist);
     }
 
-    assert_eq!(all_docs, get_all_docs(sink.get_collection("test")?).await);
+    for collection_name in &collection_names {
+        let mut all_docs = vec![];
+
+        for order_key in 0..num_batches {
+            let cursor = Some(new_cursor(order_key * batch_size));
+            let end_cursor = new_cursor((order_key + 1) * batch_size);
+            all_docs.extend(new_docs(&cursor, &end_cursor));
+        }
+
+        assert_eq!(
+            all_docs,
+            get_all_docs(sink.get_collection(collection_name)?).await
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_handle_data_empty_collection() -> Result<(), SinkMongoError> {
+    let docker = clients::Cli::default();
+    let mongo = docker.run(new_mongo_image());
+    let port = mongo.get_host_port_ipv4(27017);
+
+    let collection_names = vec!["test1".into(), "test2".into()];
+
+    let options = SinkMongoOptions {
+        connection_string: Some(format!("mongodb://localhost:{}", port)),
+        database: Some("test".into()),
+        collection_names: Some(collection_names.clone()),
+        ..SinkMongoOptions::default()
+    };
+
+    let mut sink = MongoSink::from_options(options).await?;
+
+    let cursor = Some(new_cursor(0));
+    let end_cursor = new_cursor(1);
+    let finality = DataFinality::DataStatusFinalized;
+    let ctx = Context {
+        cursor: cursor.clone(),
+        end_cursor: end_cursor.clone(),
+        finality,
+    };
+
+    // Generate data with only test1 collection
+    let batch = new_batch(&cursor, &end_cursor, &["test1".into()]);
+
+    // handle_data shouldn't fail
+    let action = sink.handle_data(&ctx, &batch).await?;
+    assert_eq!(action, CursorAction::Persist);
+
+    let all_docs = new_docs(&cursor, &end_cursor);
+
+    assert_eq!(all_docs, get_all_docs(sink.get_collection("test1")?).await);
+
+    assert_eq!(
+        Vec::<Document>::new(),
+        get_all_docs(sink.get_collection("test2")?).await,
+    );
 
     Ok(())
 }
@@ -161,11 +226,12 @@ async fn test_handle_invalidate_all(
     let mongo = docker.run(new_mongo_image());
     let port = mongo.get_host_port_ipv4(27017);
 
+    let collection_names = vec!["test1".into(), "test2".into()];
+
     let options = SinkMongoOptions {
         connection_string: Some(format!("mongodb://localhost:{}", port)),
         database: Some("test".into()),
-        collection_name: Some("test".into()),
-        collection_names: None,
+        collection_names: Some(collection_names.clone()),
         ..SinkMongoOptions::default()
     };
 
@@ -174,13 +240,11 @@ async fn test_handle_invalidate_all(
     let batch_size = 2;
     let num_batches = 5;
 
-    let mut all_docs: Vec<Document> = vec![];
-
     for order_key in 0..num_batches {
         let cursor = Some(new_cursor(order_key * batch_size));
         let end_cursor = new_cursor((order_key + 1) * batch_size);
         let finality = DataFinality::DataStatusFinalized;
-        let batch = new_batch(&cursor, &end_cursor);
+        let batch = new_batch(&cursor, &end_cursor, &collection_names);
         let ctx = Context {
             cursor: cursor.clone(),
             end_cursor: end_cursor.clone(),
@@ -190,17 +254,16 @@ async fn test_handle_invalidate_all(
         let action = sink.handle_data(&ctx, &batch).await?;
 
         assert_eq!(action, CursorAction::Persist);
-
-        all_docs.extend(new_docs(&cursor, &end_cursor));
     }
 
-    assert_eq!(all_docs, get_all_docs(sink.get_collection("test")?).await);
-
     sink.handle_invalidate(invalidate_from).await?;
-    assert_eq!(
-        Vec::<Document>::new(),
-        get_all_docs(sink.get_collection("test")?).await
-    );
+
+    for collection_name in &collection_names {
+        assert_eq!(
+            Vec::<Document>::new(),
+            get_all_docs(sink.get_collection(collection_name)?).await
+        );
+    }
 
     Ok(())
 }
@@ -224,11 +287,12 @@ async fn test_handle_invalidate() -> Result<(), SinkMongoError> {
     let mongo = docker.run(new_mongo_image());
     let port = mongo.get_host_port_ipv4(27017);
 
+    let collection_names = vec!["test1".into(), "test2".into()];
+
     let options = SinkMongoOptions {
         connection_string: Some(format!("mongodb://localhost:{}", port)),
         database: Some("test".into()),
-        collection_name: Some("test".into()),
-        collection_names: None,
+        collection_names: Some(collection_names.clone()),
         ..SinkMongoOptions::default()
     };
 
@@ -237,13 +301,11 @@ async fn test_handle_invalidate() -> Result<(), SinkMongoError> {
     let batch_size = 2;
     let num_batches = 5;
 
-    let mut all_docs: Vec<Document> = vec![];
-
     for order_key in 0..num_batches {
         let cursor = Some(new_cursor(order_key * batch_size));
         let end_cursor = new_cursor((order_key + 1) * batch_size);
         let finality = DataFinality::DataStatusFinalized;
-        let batch = new_batch(&cursor, &end_cursor);
+        let batch = new_batch(&cursor, &end_cursor, &collection_names);
         let ctx = Context {
             cursor: cursor.clone(),
             end_cursor: end_cursor.clone(),
@@ -252,33 +314,40 @@ async fn test_handle_invalidate() -> Result<(), SinkMongoError> {
 
         let action = sink.handle_data(&ctx, &batch).await?;
 
-        all_docs.extend(new_docs(&cursor, &end_cursor));
-
         assert_eq!(action, CursorAction::Persist);
     }
-
-    assert_eq!(all_docs, get_all_docs(sink.get_collection("test")?).await);
 
     let invalidate_from = 2;
 
     sink.handle_invalidate(&Some(new_cursor(invalidate_from)))
         .await?;
 
-    let expected_docs: Vec<Document> = all_docs
-        .into_iter()
-        .filter(|doc| {
-            doc.get_document("_cursor")
-                .unwrap()
-                .get_i64("from")
-                .unwrap() as u64
-                <= invalidate_from
-        })
-        .collect();
+    for collection_name in &collection_names {
+        let mut all_docs: Vec<Document> = vec![];
 
-    assert_eq!(
-        expected_docs,
-        get_all_docs(sink.get_collection("test")?).await
-    );
+        for order_key in 0..num_batches {
+            let cursor = Some(new_cursor(order_key * batch_size));
+            let end_cursor = new_cursor((order_key + 1) * batch_size);
+
+            all_docs.extend(new_docs(&cursor, &end_cursor));
+        }
+
+        let expected_docs: Vec<Document> = all_docs
+            .into_iter()
+            .filter(|doc| {
+                doc.get_document("_cursor")
+                    .unwrap()
+                    .get_i64("from")
+                    .unwrap() as u64
+                    <= invalidate_from
+            })
+            .collect();
+
+        assert_eq!(
+            expected_docs,
+            get_all_docs(sink.get_collection(collection_name)?).await
+        );
+    }
 
     Ok(())
 }
@@ -290,11 +359,12 @@ async fn test_handle_invalidate_with_extra_condition() -> Result<(), SinkMongoEr
     let mongo = docker.run(new_mongo_image());
     let port = mongo.get_host_port_ipv4(27017);
 
+    let collection_names = vec!["test1".into(), "test2".into()];
+
     let options = SinkMongoOptions {
         connection_string: Some(format!("mongodb://localhost:{}", port)),
         database: Some("test".into()),
-        collection_name: Some("test".into()),
-        collection_names: Some(vec!["test".into(), "test2".into()]),
+        collection_names: Some(collection_names.clone()),
         invalidate: Some(doc! { "col1": "a", "col2": "a" }),
         ..SinkMongoOptions::default()
     };
@@ -304,6 +374,7 @@ async fn test_handle_invalidate_with_extra_condition() -> Result<(), SinkMongoEr
     let batch_size = 2;
     let num_batches = 5;
 
+    let num_collections = collection_names.len() as u64;
     let mut docs_count = 0;
 
     for order_key in 0..num_batches {
@@ -317,36 +388,48 @@ async fn test_handle_invalidate_with_extra_condition() -> Result<(), SinkMongoEr
         };
 
         {
-            let batch =
-                new_batch_with_extra(&cursor, &end_cursor, json!({ "col1": "a", "col2": "a" }));
-            docs_count += batch_size;
+            let batch = new_batch_with_extra(
+                &cursor,
+                &end_cursor,
+                json!({ "col1": "a", "col2": "a" }),
+                &collection_names,
+            );
+            docs_count += batch_size * num_collections;
             let action = sink.handle_data(&ctx, &batch).await?;
             assert_eq!(action, CursorAction::Persist);
         }
 
         {
-            let batch =
-                new_batch_with_extra(&cursor, &end_cursor, json!({ "col1": "a", "col2": "b" }));
-            docs_count += batch_size;
+            let batch = new_batch_with_extra(
+                &cursor,
+                &end_cursor,
+                json!({ "col1": "a", "col2": "b" }),
+                &collection_names,
+            );
+            docs_count += batch_size * num_collections;
             let action = sink.handle_data(&ctx, &batch).await?;
             assert_eq!(action, CursorAction::Persist);
         }
     }
 
-    assert_eq!(docs_count, batch_size * num_batches * 2);
+    assert_eq!(docs_count, batch_size * num_batches * 2 * num_collections);
 
     let invalidate_from = 2;
 
     sink.handle_invalidate(&Some(new_cursor(invalidate_from)))
         .await?;
 
-    // We expect all documents for `{col1: a, col2: b}`, but only
-    // one batch worth of data for `{col1: a, col2: a}`.
-    let expected_docs_count = (batch_size * num_batches) + (batch_size * (invalidate_from - 1));
-    assert_eq!(
-        expected_docs_count,
-        get_all_docs(sink.get_collection("test")?).await.len() as u64
-    );
+    for collection_name in &collection_names {
+        // We expect all documents for `{col1: a, col2: b}`, but only
+        // one batch worth of data for `{col1: a, col2: a}`.
+        let expected_docs_count = (batch_size * num_batches) + (batch_size * (invalidate_from - 1));
+        assert_eq!(
+            expected_docs_count,
+            get_all_docs(sink.get_collection(collection_name)?)
+                .await
+                .len() as u64
+        );
+    }
 
     Ok(())
 }
@@ -358,11 +441,13 @@ async fn test_handle_data_in_entity_mode() -> Result<(), SinkMongoError> {
     let mongo = docker.run(new_mongo_image());
     let port = mongo.get_host_port_ipv4(27017);
 
+    let collection_names = vec!["test1".into(), "test2".into()];
+
     let options = SinkMongoOptions {
         connection_string: Some(format!("mongodb://localhost:{}", port)),
         database: Some("test".into()),
-        collection_name: Some("test".into()),
-        collection_names: None,
+        collection_name: None,
+        collection_names: Some(collection_names.clone()),
         entity_mode: Some(true),
         invalidate: None,
     };
@@ -370,17 +455,17 @@ async fn test_handle_data_in_entity_mode() -> Result<(), SinkMongoError> {
     let mut sink = MongoSink::from_options(options).await?;
     let finality = DataFinality::DataStatusFinalized;
 
-    {
+    for collection_name in &collection_names {
         // Insert the first batch.
         // Note that (0x1, 2) has duplicate items. Technically this is allowed but values will be
         // squashed.
         let cursor = Some(new_cursor(0));
         let end_cursor = new_cursor(1);
         let batch = json!([
-            json!({"entity": { "address": "0x1", "token_id": "1", }, "update": { "$set": { "v0": "a", "v1": "a" } } }),
-            json!({"entity": { "address": "0x1", "token_id": "2", }, "update": { "$set": { "v0": "b", "v1": "b" } } }),
-            json!({"entity": { "address": "0x1", "token_id": "2", }, "update": [{ "$set": { "v0": "a", "v1": "a" } }] }),
-            json!({"entity": { "address": "0x1", "token_id": "3", }, "update": [{ "$set": { "v0": "a", "v1": "a" } }] }),
+            json!({"entity": { "address": "0x1", "token_id": "1", }, "update": { "$set": { "v0": "a", "v1": "a" } }, "collection": collection_name }),
+            json!({"entity": { "address": "0x1", "token_id": "2", }, "update": { "$set": { "v0": "b", "v1": "b" } }, "collection": collection_name }),
+            json!({"entity": { "address": "0x1", "token_id": "2", }, "update": [{ "$set": { "v0": "a", "v1": "a" } }], "collection": collection_name }),
+            json!({"entity": { "address": "0x1", "token_id": "3", }, "update": [{ "$set": { "v0": "a", "v1": "a" } }], "collection": collection_name }),
         ]);
 
         let ctx = Context {
@@ -392,13 +477,13 @@ async fn test_handle_data_in_entity_mode() -> Result<(), SinkMongoError> {
         sink.handle_data(&ctx, &batch).await?;
     }
 
-    {
+    for collection_name in &collection_names {
         // Update some values for some entities.
         let cursor = Some(new_cursor(1));
         let end_cursor = new_cursor(2);
         let batch = json!([
-            json!({"entity": { "address": "0x1", "token_id": "1", }, "update": { "$set": { "v1": "b"}, "$inc": { "v2": 7 } } }),
-            json!({"entity": { "address": "0x1", "token_id": "2", }, "update": [{ "$set": { "v0": "b"} }] }),
+            json!({"entity": { "address": "0x1", "token_id": "1", }, "update": { "$set": { "v1": "b"}, "$inc": { "v2": 7 } }, "collection": collection_name }),
+            json!({"entity": { "address": "0x1", "token_id": "2", }, "update": [{ "$set": { "v0": "b"} }], "collection": collection_name }),
         ]);
 
         let ctx = Context {
@@ -408,12 +493,14 @@ async fn test_handle_data_in_entity_mode() -> Result<(), SinkMongoError> {
         };
 
         sink.handle_data(&ctx, &batch).await?;
+    }
 
+    for collection_name in &collection_names {
         // Check that the values were updated correctly.
         // For example, we check that key v0 is still present.
 
         let new_docs = sink
-            .get_collection("test")?
+            .get_collection(collection_name)?
             .find(
                 Some(doc! {"_cursor.to": Bson::Null, "address": "0x1", "token_id": "1" }),
                 None,
@@ -431,7 +518,7 @@ async fn test_handle_data_in_entity_mode() -> Result<(), SinkMongoError> {
         assert_eq!(new_doc.get_i64("v2").unwrap(), 7);
 
         let new_docs = sink
-            .get_collection("test")?
+            .get_collection(collection_name)?
             .find(
                 Some(doc! {"_cursor.to": Bson::Null, "address": "0x1", "token_id": "2" }),
                 None,
@@ -445,13 +532,13 @@ async fn test_handle_data_in_entity_mode() -> Result<(), SinkMongoError> {
         assert_eq!(new_docs.len(), 1);
     }
 
-    {
+    for collection_name in &collection_names {
         // Update a single entity and insert a new one.
         let cursor = Some(new_cursor(2));
         let end_cursor = new_cursor(3);
         let batch = json!([
-            json!({ "entity": { "address": "0x1", "token_id": "1" }, "update": { "$set": { "v1": "c" } } }),
-            json!({ "entity": { "address": "0x1", "token_id": "4" }, "update": { "$set": { "v0": "a", "v1": "a" } } }),
+            json!({ "entity": { "address": "0x1", "token_id": "1" }, "update": { "$set": { "v1": "c" } }, "collection": collection_name }),
+            json!({ "entity": { "address": "0x1", "token_id": "4" }, "update": { "$set": { "v0": "a", "v1": "a" } }, "collection": collection_name }),
         ]);
 
         let ctx = Context {
@@ -461,9 +548,11 @@ async fn test_handle_data_in_entity_mode() -> Result<(), SinkMongoError> {
         };
 
         sink.handle_data(&ctx, &batch).await?;
+    }
 
+    for collection_name in &collection_names {
         let updated_docs = sink
-            .get_collection("test")?
+            .get_collection(collection_name)?
             .find(
                 Some(doc! {"_cursor.to": Bson::Null, "address": "0x1", "token_id": "1" }),
                 None,
@@ -480,7 +569,7 @@ async fn test_handle_data_in_entity_mode() -> Result<(), SinkMongoError> {
         assert_eq!(updated_doc.get_str("v1").unwrap(), "c");
 
         let new_docs = sink
-            .get_collection("test")?
+            .get_collection(collection_name)?
             .find(
                 Some(doc! {"_cursor.to": Bson::Null, "address": "0x1", "token_id": "4" }),
                 None,
@@ -507,11 +596,13 @@ async fn test_handle_invalidate_in_entity_mode() -> Result<(), SinkMongoError> {
     let mongo = docker.run(new_mongo_image());
     let port = mongo.get_host_port_ipv4(27017);
 
+    let collection_names = vec!["test1".into(), "test2".into()];
+
     let options = SinkMongoOptions {
         connection_string: Some(format!("mongodb://localhost:{}", port)),
         database: Some("test".into()),
-        collection_name: Some("test".into()),
-        collection_names: None,
+        collection_name: None,
+        collection_names: Some(collection_names.clone()),
         entity_mode: Some(true),
         invalidate: None,
     };
@@ -519,12 +610,12 @@ async fn test_handle_invalidate_in_entity_mode() -> Result<(), SinkMongoError> {
     let mut sink = MongoSink::from_options(options).await?;
     let finality = DataFinality::DataStatusFinalized;
 
-    {
+    for collection_name in &collection_names {
         let cursor = Some(new_cursor(0));
         let end_cursor = new_cursor(1);
         let batch = json!([
-            json!({ "entity": { "address": "0x1", "token_id": "1" }, "update": { "$set": { "v0": "a", "v1": "a" } } }),
-            json!({ "entity": { "address": "0x1", "token_id": "2" }, "update": { "$set": { "v0": "a", "v1": "a"} } }),
+            json!({ "entity": { "address": "0x1", "token_id": "1" }, "update": { "$set": { "v0": "a", "v1": "a" } }, "collection": collection_name }),
+            json!({ "entity": { "address": "0x1", "token_id": "2" }, "update": { "$set": { "v0": "a", "v1": "a"} }, "collection": collection_name }),
         ]);
 
         let ctx = Context {
@@ -536,11 +627,11 @@ async fn test_handle_invalidate_in_entity_mode() -> Result<(), SinkMongoError> {
         sink.handle_data(&ctx, &batch).await?;
     }
 
-    {
+    for collection_name in &collection_names {
         let cursor = Some(new_cursor(1));
         let end_cursor = new_cursor(2);
         let batch = json!([
-            json!({ "entity": { "address": "0x1", "token_id": "2" }, "update": { "$set": { "v1": "b" } } }),
+            json!({ "entity": { "address": "0x1", "token_id": "2" }, "update": { "$set": { "v1": "b" } }, "collection": collection_name }),
         ]);
 
         let ctx = Context {
@@ -552,7 +643,7 @@ async fn test_handle_invalidate_in_entity_mode() -> Result<(), SinkMongoError> {
         sink.handle_data(&ctx, &batch).await?;
 
         let new_docs = sink
-            .get_collection("test")?
+            .get_collection(collection_name)?
             .find(
                 Some(doc! { "token_id": "2", "_cursor.to": Bson::Null }),
                 None,
@@ -569,14 +660,14 @@ async fn test_handle_invalidate_in_entity_mode() -> Result<(), SinkMongoError> {
         assert_eq!(new_doc.get_str("v1").unwrap(), "b");
     }
 
-    {
-        // This actually shouldn't invalidate any data since the new heade is the same as before
+    for collection_name in &collection_names {
+        // This actually shouldn't invalidate any data since the new head is the same as before
         // (2), but it catches off by one errors in the invalidation logic.
         let new_head = Some(new_cursor(2));
         sink.handle_invalidate(&new_head).await?;
 
         let new_docs = sink
-            .get_collection("test")?
+            .get_collection(collection_name)?
             .find(
                 Some(doc! { "token_id": "2", "_cursor.to": Bson::Null }),
                 None,
@@ -593,13 +684,13 @@ async fn test_handle_invalidate_in_entity_mode() -> Result<(), SinkMongoError> {
         assert_eq!(new_doc.get_str("v1").unwrap(), "b");
     }
 
-    {
+    for collection_name in &collection_names {
         // Now actually invalidate data.
         let new_head = Some(new_cursor(1));
         sink.handle_invalidate(&new_head).await?;
 
         let new_docs = sink
-            .get_collection("test")?
+            .get_collection(collection_name)?
             .find(
                 Some(doc! { "token_id": "2", "_cursor.to": Bson::Null }),
                 None,


### PR DESCRIPTION
Users can now add a "collection" key to the value returned from the transform function to specify the name of the collection

Fixes #278 