### PR TITLE
operator: optionally limit operator to a namespace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-operator"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "apibara-observability",
  "clap",

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2023-12-12
+
+_Limit operator to watch a single namespace._
+
+### Added
+
+-   Add a new `--namespace` flag to limit watching indexers in a single namespace.
+
 ## [0.2.0] - 2023-12-11
 
 _Add support for private GitHub repositories._
@@ -17,4 +25,5 @@ _Add support for private GitHub repositories._
     the secret together with the `access_token_env_var` to authenticate with GitHub
     on clone.
 
+[0.2.1]: https://github.com/apibara/dna/releases/tag/operator/v0.2.1
 [0.2.0]: https://github.com/apibara/dna/releases/tag/operator/v0.2.0

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-operator"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 
 [lib]

--- a/operator/src/bin.rs
+++ b/operator/src/bin.rs
@@ -34,6 +34,9 @@ struct GenerateCrdArgs {}
 struct StartArgs {
     #[clap(flatten)]
     pub sink: SinkArgs,
+    /// Limit the namespace the operator watches.
+    #[arg(long, env)]
+    pub namespace: Option<String>,
 }
 
 #[derive(Args, Debug)]
@@ -101,7 +104,10 @@ async fn main() -> Result<(), OperatorError> {
 
 impl StartArgs {
     pub fn into_configuration(self) -> Result<Configuration, OperatorError> {
-        let mut configuration = Configuration::default();
+        let mut configuration = Configuration {
+            namespace: self.namespace,
+            ..Configuration::default()
+        };
 
         if let Some(sink_images) = self.sink.sink_images {
             let mut sinks = HashMap::new();

--- a/operator/src/configuration.rs
+++ b/operator/src/configuration.rs
@@ -12,6 +12,8 @@ pub struct Configuration {
     pub sinks: HashMap<String, SinkConfiguration>,
     /// Sink status port.
     pub status_port: i32,
+    /// Limit the namespace the operator watches.
+    pub namespace: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -56,6 +58,7 @@ impl Default for Configuration {
         Configuration {
             sinks,
             status_port: 8118,
+            namespace: None,
         }
     }
 }

--- a/operator/src/controller.rs
+++ b/operator/src/controller.rs
@@ -33,12 +33,17 @@ pub async fn create(
 ) -> Result<impl Stream<Item = ReconcileItem<Indexer>>, OperatorError> {
     info!("Creating controller");
 
+    let namespace = configuration.namespace.clone();
     let ctx = Context {
         client,
         configuration,
     };
 
-    let indexers = Api::<Indexer>::all(ctx.client.clone());
+    let indexers = if let Some(namespace) = &namespace {
+        Api::<Indexer>::namespaced(ctx.client.clone(), namespace)
+    } else {
+        Api::<Indexer>::all(ctx.client.clone())
+    };
 
     if indexers.list(&ListParams::default()).await.is_err() {
         error!("Indexer CRD not installed");


### PR DESCRIPTION
operator: optionally limit operator to a namespace

**Summary**
For production usage, users may need to configure the operator
differently based on the use. With this change, they can limit the
operator to a single namespace.

release: operator v0.2.1