### PR TITLE
operator: fix CRD capitalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-operator"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "apibara-observability",
  "clap",

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2023-12-12
+
+_Fix Indexer CRD._
+
+### Fixed
+
+-   Fix capitalization in the `Indexer` CRD.
+
 ## [0.2.1] - 2023-12-12
 
 _Limit operator to watch a single namespace._
@@ -25,5 +33,6 @@ _Add support for private GitHub repositories._
     the secret together with the `access_token_env_var` to authenticate with GitHub
     on clone.
 
+[0.2.2]: https://github.com/apibara/dna/releases/tag/operator/v0.2.2
 [0.2.1]: https://github.com/apibara/dna/releases/tag/operator/v0.2.1
 [0.2.0]: https://github.com/apibara/dna/releases/tag/operator/v0.2.0

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-operator"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 
 [lib]

--- a/operator/src/crd.rs
+++ b/operator/src/crd.rs
@@ -43,6 +43,7 @@ pub enum IndexerSource {
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct GitHubSource {
     /// GitHub repository owner, e.g. `my-org`.
     pub owner: String,
@@ -61,6 +62,7 @@ pub struct GitHubSource {
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct VolumeSource {
     /// Path to the indexer source code, e.g. `/myvolume`.
     ///
@@ -70,6 +72,7 @@ pub struct VolumeSource {
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, JsonSchema, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct Sink {
     /// Container image with the sink.
     #[serde(flatten)]
@@ -88,6 +91,7 @@ pub enum SinkType {
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct IndexerVolume {
     /// Volume to mount.
     pub volume: Volume,


### PR DESCRIPTION
operator: fix CRD capitalization

**Summary**
CRD was using snake case, but the k8s convention is to use camel case.

release: operator v0.2.2