### PR TITLE
starknet: update to RPC v0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7395,8 +7395,8 @@ dependencies = [
 
 [[package]]
 name = "starknet"
-version = "0.7.0"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=64ebc36#64ebc364c0c346e81b715c5b4a3b32ef37b055c8"
+version = "0.8.0"
+source = "git+https://github.com/fracek/starknet-rs?rev=e6c4a21a7ce5#e6c4a21a7ce53c5fb3faa2f8dc9d71dd5afe4342"
 dependencies = [
  "starknet-accounts",
  "starknet-contract",
@@ -7410,8 +7410,8 @@ dependencies = [
 
 [[package]]
 name = "starknet-accounts"
-version = "0.6.1"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=64ebc36#64ebc364c0c346e81b715c5b4a3b32ef37b055c8"
+version = "0.7.0"
+source = "git+https://github.com/fracek/starknet-rs?rev=e6c4a21a7ce5#e6c4a21a7ce53c5fb3faa2f8dc9d71dd5afe4342"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -7423,8 +7423,8 @@ dependencies = [
 
 [[package]]
 name = "starknet-contract"
-version = "0.6.0"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=64ebc36#64ebc364c0c346e81b715c5b4a3b32ef37b055c8"
+version = "0.7.0"
+source = "git+https://github.com/fracek/starknet-rs?rev=e6c4a21a7ce5#e6c4a21a7ce53c5fb3faa2f8dc9d71dd5afe4342"
 dependencies = [
  "serde",
  "serde_json",
@@ -7437,8 +7437,8 @@ dependencies = [
 
 [[package]]
 name = "starknet-core"
-version = "0.7.2"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=64ebc36#64ebc364c0c346e81b715c5b4a3b32ef37b055c8"
+version = "0.8.0"
+source = "git+https://github.com/fracek/starknet-rs?rev=e6c4a21a7ce5#e6c4a21a7ce53c5fb3faa2f8dc9d71dd5afe4342"
 dependencies = [
  "base64 0.21.5",
  "flate2",
@@ -7455,7 +7455,7 @@ dependencies = [
 [[package]]
 name = "starknet-crypto"
 version = "0.6.1"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=64ebc36#64ebc364c0c346e81b715c5b4a3b32ef37b055c8"
+source = "git+https://github.com/fracek/starknet-rs?rev=e6c4a21a7ce5#e6c4a21a7ce53c5fb3faa2f8dc9d71dd5afe4342"
 dependencies = [
  "crypto-bigint 0.5.3",
  "hex",
@@ -7474,7 +7474,7 @@ dependencies = [
 [[package]]
 name = "starknet-crypto-codegen"
 version = "0.3.2"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=64ebc36#64ebc364c0c346e81b715c5b4a3b32ef37b055c8"
+source = "git+https://github.com/fracek/starknet-rs?rev=e6c4a21a7ce5#e6c4a21a7ce53c5fb3faa2f8dc9d71dd5afe4342"
 dependencies = [
  "starknet-curve",
  "starknet-ff",
@@ -7484,15 +7484,15 @@ dependencies = [
 [[package]]
 name = "starknet-curve"
 version = "0.4.0"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=64ebc36#64ebc364c0c346e81b715c5b4a3b32ef37b055c8"
+source = "git+https://github.com/fracek/starknet-rs?rev=e6c4a21a7ce5#e6c4a21a7ce53c5fb3faa2f8dc9d71dd5afe4342"
 dependencies = [
  "starknet-ff",
 ]
 
 [[package]]
 name = "starknet-ff"
-version = "0.3.5"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=64ebc36#64ebc364c0c346e81b715c5b4a3b32ef37b055c8"
+version = "0.3.6"
+source = "git+https://github.com/fracek/starknet-rs?rev=e6c4a21a7ce5#e6c4a21a7ce53c5fb3faa2f8dc9d71dd5afe4342"
 dependencies = [
  "ark-ff",
  "bigdecimal",
@@ -7505,8 +7505,8 @@ dependencies = [
 
 [[package]]
 name = "starknet-macros"
-version = "0.1.4"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=64ebc36#64ebc364c0c346e81b715c5b4a3b32ef37b055c8"
+version = "0.1.5"
+source = "git+https://github.com/fracek/starknet-rs?rev=e6c4a21a7ce5#e6c4a21a7ce53c5fb3faa2f8dc9d71dd5afe4342"
 dependencies = [
  "starknet-core",
  "syn 2.0.38",
@@ -7514,8 +7514,8 @@ dependencies = [
 
 [[package]]
 name = "starknet-providers"
-version = "0.7.0"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=64ebc36#64ebc364c0c346e81b715c5b4a3b32ef37b055c8"
+version = "0.8.0"
+source = "git+https://github.com/fracek/starknet-rs?rev=e6c4a21a7ce5#e6c4a21a7ce53c5fb3faa2f8dc9d71dd5afe4342"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -7533,8 +7533,8 @@ dependencies = [
 
 [[package]]
 name = "starknet-signers"
-version = "0.5.0"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=64ebc36#64ebc364c0c346e81b715c5b4a3b32ef37b055c8"
+version = "0.6.0"
+source = "git+https://github.com/fracek/starknet-rs?rev=e6c4a21a7ce5#e6c4a21a7ce53c5fb3faa2f8dc9d71dd5afe4342"
 dependencies = [
  "async-trait",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,10 +81,8 @@ reqwest = { version = "0.11.16", default-features = false, features = [
 regex = "1.9.1"
 serde = "1.0.155"
 serde_json = "1.0.94"
-starknet = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "64ebc36" }
-# - relax flate2 dependency
-# - relax log dependency
-# starknet = { git = "https://github.com/fracek/starknet-rs", rev = "06d78d1" }
+# starknet = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "6cadb1986" }
+starknet = { git = "https://github.com/fracek/starknet-rs", rev = "e6c4a21a7ce5" }
 thiserror = "1.0.32"
 tempfile = "3.3.0"
 tempdir = "0.3.7"

--- a/core/proto/starknet/v1alpha2/starknet.proto
+++ b/core/proto/starknet/v1alpha2/starknet.proto
@@ -112,6 +112,8 @@ message TransactionMeta {
   DataAvailabilityMode nonce_data_availability_mode = 9;
   // The storage domain of the account's balance from which fee will be charged.
   DataAvailabilityMode fee_data_availability_mode = 10;
+  // Index of the transaction in the block.
+  uint64 transaction_index = 11;
 }
 
 // Transaction invoking a smart contract, V0.

--- a/core/proto/starknet/v1alpha2/starknet.proto
+++ b/core/proto/starknet/v1alpha2/starknet.proto
@@ -36,6 +36,10 @@ message BlockHeader {
   FieldElement new_root = 5;
   // Timestamp when block  was produced.
   google.protobuf.Timestamp timestamp = 6;
+  // Starknet version.
+  string starknet_version = 7;
+  // Price of L1 gas in the block.
+  ResourcePrice l1_gas_price = 8;
 }
 
 // Status of a block.
@@ -69,7 +73,7 @@ message Transaction {
     InvokeTransactionV0 invoke_v0 = 2;
     // Transaction invoking a smart contract, V1.
     InvokeTransactionV1 invoke_v1 = 3;
-    // Transaction deploying a new smart contract.
+    // Transaction deploying a new smart contract, V1.
     DeployTransaction deploy = 4;
     // Transaction declaring a smart contract.
     DeclareTransaction declare = 5;
@@ -77,6 +81,12 @@ message Transaction {
     L1HandlerTransaction l1_handler = 6;
     // Transaction deploying a new account.
     DeployAccountTransaction deploy_account = 7;
+    // Transaction deploying a new smart contract, V3.
+    DeployAccountTransactionV3 deploy_account_v3 = 8;
+    // Transaction invoking a smart contract, V3.
+    InvokeTransactionV3 invoke_v3 = 9;
+    // Transaction declaring a smart contract, V3.
+    DeclareTransactionV3 declare_v3 = 10;
   }
 }
 
@@ -92,6 +102,16 @@ message TransactionMeta {
   FieldElement nonce = 4;
   // Version.
   uint64 version = 5;
+  // Transaction resources.
+  ResourceBoundsMapping resource_bounds = 6;
+  // Tip to the sequencer.
+  uint64 tip = 7;
+  // Data passed to the paymaster.
+  repeated FieldElement paymaster_data = 8;
+  // The storage domain of the account's nonce.
+  DataAvailabilityMode nonce_data_availability_mode = 9;
+  // The storage domain of the account's balance from which fee will be charged.
+  DataAvailabilityMode fee_data_availability_mode = 10;
 }
 
 // Transaction invoking a smart contract, V0.
@@ -112,7 +132,17 @@ message InvokeTransactionV1 {
   repeated FieldElement calldata = 2;
 }
 
-// Transaction deploying a new smart contract.
+// Transaction invoking a smart contract, V3.
+message InvokeTransactionV3 {
+  // Address sending the transaction.
+  FieldElement sender_address = 1;
+  // Raw calldata.
+  repeated FieldElement calldata = 2;
+  // Data passed to the account deployment.
+  repeated FieldElement account_deployment_data = 3;
+}
+
+// Transaction deploying a new smart contract, V1.
 message DeployTransaction {
   // Raw calldata passed to the constructor.
   repeated FieldElement constructor_calldata = 2;
@@ -130,6 +160,18 @@ message DeclareTransaction {
   FieldElement sender_address = 2;
   // The hash of the cairo assembly resulting from the sierra compilation.
   FieldElement compiled_class_hash = 3;
+}
+
+// Transaction declaring a smart contract.
+message DeclareTransactionV3 {
+  // Class hash.
+  FieldElement class_hash = 1;
+  // Address of the account declaring the class.
+  FieldElement sender_address = 2;
+  // The hash of the cairo assembly resulting from the sierra compilation.
+  FieldElement compiled_class_hash = 3;
+  // Data passed to the account deployment.
+  repeated FieldElement account_deployment_data = 4;
 }
 
 // Transaction handling a message from L1.
@@ -152,6 +194,16 @@ message DeployAccountTransaction {
   FieldElement class_hash = 4;
 }
 
+// Transaction deploying a new smart contract, V3.
+message DeployAccountTransactionV3 {
+  // Raw calldata passed to the constructor.
+  repeated FieldElement constructor_calldata = 1;
+  // Salt used when computing the contract's address.
+  FieldElement contract_address_salt = 2;
+  // Hash of the class being deployed.
+  FieldElement class_hash = 3;
+}
+
 // Transaction execution status.
 enum ExecutionStatus {
   // Unknown execution status.
@@ -172,7 +224,7 @@ message TransactionReceipt {
   // Transaction's indexe in the list of transactions in a block.
   uint64 transaction_index = 2;
   // Feed paid.
-  FieldElement actual_fee = 3;
+  FieldElement actual_fee = 3 [ deprecated = true ];
   // Messages sent to L1 in the transactions.
   repeated L2ToL1Message l2_to_l1_messages = 4;
   // Events emitted in the transaction.
@@ -183,6 +235,8 @@ message TransactionReceipt {
   ExecutionStatus execution_status = 7;
   // The reason why the transaction reverted.
   string revert_reason = 8;
+  // Feed paid.
+  FeePayment actual_fee_paid = 9;
 }
 
 // Message sent from L2 to L1 together with its transaction and receipt.
@@ -307,4 +361,61 @@ message NonceUpdate {
   FieldElement contract_address = 1;
   // New nonce value.
   FieldElement nonce = 2;
+}
+
+// Price of a unit of a resource.
+message ResourcePrice {
+  // Price in fri (10^-18 strk).
+  FieldElement price_in_fri = 1;
+  // Price in wei (10^-18 eth).
+  FieldElement price_in_wei = 2;
+}
+
+// A Starknet fee payment.
+message FeePayment {
+  // Amount paid.
+  FieldElement amount = 1;
+  // Unit of the amount.
+  PriceUnit unit = 2;
+}
+
+// Price unit.
+enum PriceUnit {
+  // Unknown price unit.
+  PRICE_UNIT_UNSPECIFIED = 0;
+  // WEI.
+  PRICE_UNIT_WEI = 1;
+  // FRI.
+  PRICE_UNIT_FRI = 2;
+}
+
+message ResourceBoundsMapping {
+  // Maximum amount and price of L1 gas.
+  ResourceBounds l1_gas = 1;
+  // Maximum amount and price of L2 gas.
+  ResourceBounds l2_gas = 2;
+}
+
+message ResourceBounds {
+  // The maximum amount of resources that can be consumed by a transaction.
+  uint64 max_amount = 1;
+  /// The max price per unit of resource.
+  Uint128 max_price_per_unit = 2;
+}
+
+message Uint128 {
+  // The low 64 bits of the number.
+  uint64 low = 1;
+  // The high 64 bits of the number.
+  uint64 high = 2;
+}
+
+// DA mode.
+enum DataAvailabilityMode {
+  // Unknown DA.
+  DATA_AVAILABILITY_MODE_UNSPECIFIED = 0;
+  // L1.
+  DATA_AVAILABILITY_MODE_L1 = 1;
+  // L2.
+  DATA_AVAILABILITY_MODE_L2 = 2;
 }

--- a/starknet/src/ingestion/config.rs
+++ b/starknet/src/ingestion/config.rs
@@ -15,7 +15,7 @@ pub struct BlockIngestionConfig {
 impl Default for BlockIngestionConfig {
     fn default() -> Self {
         BlockIngestionConfig {
-            rpc_concurrency: 16,
+            rpc_concurrency: 64,
             head_refresh_interval: Duration::from_secs(3),
             ingestion_starting_block: None,
         }

--- a/starknet/src/provider.rs
+++ b/starknet/src/provider.rs
@@ -317,14 +317,40 @@ impl ToProto<v1alpha2::ResourcePrice> for models::ResourcePrice {
 
 impl ToProto<BlockBody> for models::BlockWithTxs {
     fn to_proto(&self) -> BlockBody {
-        let transactions = self.transactions.iter().map(|tx| tx.to_proto()).collect();
+        let transactions = self
+            .transactions
+            .iter()
+            .enumerate()
+            .map(|(idx, tx)| {
+                let mut proto = tx.to_proto();
+                proto
+                    .meta
+                    .as_mut()
+                    .expect("transaction meta")
+                    .transaction_index = idx as u64;
+                proto
+            })
+            .collect();
         BlockBody { transactions }
     }
 }
 
 impl ToProto<BlockBody> for models::PendingBlockWithTxs {
     fn to_proto(&self) -> BlockBody {
-        let transactions = self.transactions.iter().map(|tx| tx.to_proto()).collect();
+        let transactions = self
+            .transactions
+            .iter()
+            .enumerate()
+            .map(|(idx, tx)| {
+                let mut proto = tx.to_proto();
+                proto
+                    .meta
+                    .as_mut()
+                    .expect("transaction meta")
+                    .transaction_index = idx as u64;
+                proto
+            })
+            .collect();
         BlockBody { transactions }
     }
 }
@@ -458,6 +484,7 @@ impl ToProto<v1alpha2::Transaction> for models::InvokeTransactionV3 {
             paymaster_data,
             nonce_data_availability_mode: nonce_data_availability_mode as i32,
             fee_data_availability_mode: fee_data_availability_mode as i32,
+            transaction_index: 0,
         };
 
         let sender_address = self.sender_address.into();
@@ -652,6 +679,7 @@ impl ToProto<v1alpha2::Transaction> for models::DeclareTransactionV3 {
             paymaster_data,
             nonce_data_availability_mode: nonce_data_availability_mode as i32,
             fee_data_availability_mode: fee_data_availability_mode as i32,
+            transaction_index: 0,
         };
 
         let class_hash = self.class_hash.into();
@@ -781,6 +809,7 @@ impl ToProto<v1alpha2::Transaction> for models::DeployAccountTransactionV3 {
             paymaster_data,
             nonce_data_availability_mode: nonce_data_availability_mode as i32,
             fee_data_availability_mode: fee_data_availability_mode as i32,
+            transaction_index: 0,
         };
 
         let contract_address_salt = self.contract_address_salt.into();


### PR DESCRIPTION
starknet: update to RPC v0.6

**Summary**
RPC v0.6 is a big change, with new transaction types (V3) among other
things.
This commit tries to map new fields (like multi-currency fees) to the
old ones.

starknet: include transaction index in transaction

**Summary**
Transaction index can be used to generate a unique id or to order
events.