### PR TITLE
Improve sink status service

### DIFF
--- a/sinks/sink-common/src/connector.rs
+++ b/sinks/sink-common/src/connector.rs
@@ -293,7 +293,7 @@ where
         S: Sink + Sync + Send,
     {
         for duration in &self.backoff {
-            info!(cursor = ?cursor, "handle invalidate");
+            info!(cursor = %DisplayCursor(cursor), "handle invalidate");
             match self.sink.handle_invalidate(cursor).await {
                 Ok(_) => {
                     // if the sink started streaming from the genesis block

--- a/sinks/sink-common/src/connector.rs
+++ b/sinks/sink-common/src/connector.rs
@@ -142,13 +142,15 @@ where
 
         let stream_client = self.new_stream_client().await?;
 
-        let (status_client, mut status_server) = self
+        let (status_client, status_server) = self
             .status_server
             .clone()
             .start(stream_client.clone(), ct.clone())
             .await
             .change_context(SinkConnectorError::Temporary)
             .attach_printable("failed to start status server")?;
+
+        let mut status_server = tokio::spawn(status_server);
 
         // Set starting cursor now, before it's modified.
         status_client

--- a/sinks/sink-common/src/status/mod.rs
+++ b/sinks/sink-common/src/status/mod.rs
@@ -54,8 +54,8 @@ impl StatusServer {
         StatusServerError,
     > {
         let (status_service, status_client, status_service_client, health_server) =
-            StatusService::new();
-        let status_server = Server::new(status_service_client, stream_client);
+            StatusService::new(stream_client);
+        let status_server = Server::new(status_service_client);
 
         let status_fut = Box::pin({
             let address = self.address;

--- a/sinks/sink-console/src/sink.rs
+++ b/sinks/sink-console/src/sink.rs
@@ -33,7 +33,7 @@ impl Sink for ConsoleSink {
         Ok(ConsoleSink::default())
     }
 
-    #[instrument(skip(self, batch), err(Debug), level = "DEBUG")]
+    #[instrument(skip_all, err(Debug), level = "DEBUG")]
     async fn handle_data(
         &mut self,
         ctx: &Context,
@@ -50,7 +50,7 @@ impl Sink for ConsoleSink {
         Ok(CursorAction::Persist)
     }
 
-    #[instrument(skip(self), err(Debug))]
+    #[instrument(skip_all, err(Debug), level = "DEBUG")]
     async fn handle_invalidate(&mut self, cursor: &Option<Cursor>) -> Result<(), Self::Error> {
         info!(cursor = %DisplayCursor(cursor), "invalidating cursor");
         Ok(())


### PR DESCRIPTION
Publish sync related metrics to OTEL. Users can use this data to
generate grafana dashboards.

Additionally, move the status service to its dedicated task.
Previously, the indexer and the status service were running on the same
tokio task. This is an issue because the status service had to wait for
the DNA stream to finish producing messages before it could handle
updating the status. In practice, this resulted in annoying grpc timeout
errors for clients trying to access the sink status.

Moving the status service to its own task solves the issue.

