### PR TITLE
sink: refactor persistence to store state

### DIFF
--- a/sinks/sink-common/src/persistence/default.rs
+++ b/sinks/sink-common/src/persistence/default.rs
@@ -1,8 +1,7 @@
-use apibara_core::node::v1alpha2::Cursor;
 use async_trait::async_trait;
 use error_stack::Result;
 
-use crate::SinkError;
+use crate::{PersistedState, SinkError};
 
 use super::common::PersistenceClient;
 
@@ -19,15 +18,15 @@ impl PersistenceClient for NoPersistence {
         Ok(())
     }
 
-    async fn get_cursor(&mut self) -> Result<Option<Cursor>, SinkError> {
-        Ok(None)
+    async fn get_state(&mut self) -> Result<PersistedState, SinkError> {
+        Ok(PersistedState::default())
     }
 
-    async fn put_cursor(&mut self, _cursor: Cursor) -> Result<(), SinkError> {
+    async fn put_state(&mut self, _state: PersistedState) -> Result<(), SinkError> {
         Ok(())
     }
 
-    async fn delete_cursor(&mut self) -> Result<(), SinkError> {
+    async fn delete_state(&mut self) -> Result<(), SinkError> {
         Ok(())
     }
 }

--- a/sinks/sink-common/src/persistence/mod.rs
+++ b/sinks/sink-common/src/persistence/mod.rs
@@ -3,7 +3,7 @@ mod default;
 mod etcd;
 mod fs;
 
-pub use self::common::PersistenceClient;
+pub use self::common::{PersistedState, PersistenceClient};
 pub use self::default::NoPersistence;
 pub use self::etcd::EtcdPersistence;
 pub use self::fs::DirPersistence;


### PR DESCRIPTION
**Summary**
Adding support for factories requires tracking the dynamic filter built
by listening to factory events. We are going to use the same persistence
mechanism used to track the indexer's cursor to track the filter.

This commit changes the data stored in the persistence layer to be a
struct that can be extended later.