### PR TITLE
starknet: implement multi-filter

### DIFF
--- a/core/proto/node/v1alpha2/stream.proto
+++ b/core/proto/node/v1alpha2/stream.proto
@@ -7,7 +7,8 @@ service Stream {
   // Stream data from the node (bi-directional).
   rpc StreamData(stream StreamDataRequest) returns (stream StreamDataResponse);
   // Stream data from the node.
-  rpc StreamDataImmutable(StreamDataRequest) returns (stream StreamDataResponse);
+  rpc StreamDataImmutable(StreamDataRequest)
+      returns (stream StreamDataResponse);
   // Get DNA service status.
   rpc Status(StatusRequest) returns (StatusResponse);
 }
@@ -26,6 +27,8 @@ message StreamDataRequest {
   optional DataFinality finality = 4;
   // Return data according to the stream-specific filter.
   bytes filter = 5;
+  // Combine multiple filters in the same stream.
+  repeated bytes multi_filter = 6;
 }
 
 // Contains the data requested from the client.
@@ -80,8 +83,7 @@ message Data {
 message Heartbeat {}
 
 // Request for the `Status` method.
-message StatusRequest {
-}
+message StatusRequest {}
 
 // Response for the `Status` method.
 message StatusResponse {

--- a/core/proto/starknet/v1alpha2/starknet.proto
+++ b/core/proto/starknet/v1alpha2/starknet.proto
@@ -20,6 +20,8 @@ message Block {
   repeated EventWithTransaction events = 5;
   // Messages to L1 sent in the block.
   repeated L2ToL1MessageWithTransaction l2_to_l1_messages = 6;
+  // Whether the block contains data.
+  bool empty = 7;
 }
 
 // Block header.

--- a/core/src/node.rs
+++ b/core/src/node.rs
@@ -106,6 +106,20 @@ pub mod v1alpha2 {
             deserializer.deserialize_struct("Cursor", FIELDS, CursorVisitor)
         }
     }
+
+    impl DataFinality {
+        pub fn is_pending(&self) -> bool {
+            matches!(self, DataFinality::DataStatusPending)
+        }
+
+        pub fn is_accepted(&self) -> bool {
+            matches!(self, DataFinality::DataStatusAccepted)
+        }
+
+        pub fn is_finalized(&self) -> bool {
+            matches!(self, DataFinality::DataStatusFinalized)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/sdk/src/configuration.rs
+++ b/sdk/src/configuration.rs
@@ -62,6 +62,7 @@ where
             starting_cursor: self.starting_cursor,
             finality: self.finality.map(Into::into),
             filter,
+            multi_filter: Vec::default(),
         })
     }
 

--- a/starknet/src/stream/cursor_producer.rs
+++ b/starknet/src/stream/cursor_producer.rs
@@ -460,7 +460,7 @@ mod tests {
             stream_id: 0,
             finality,
             starting_cursor,
-            filter: Filter::default(),
+            filter: vec![Filter::default()],
         }
     }
 


### PR DESCRIPTION
**Summary**
To implement factories, we need a way to stream data in two separate but
synchronized streams.
This PR introduces the concept of "multi filter":

 - clients enter multi-filter mode by specifying multiple filters in the
   request. To keep backward compatibility, the server still accepts the
   old requests.
 - batch size must be 1.
 - response includes one block for each filter (using the same field as
   batched block data, hence why batch size must be 1).
 - if no filter matches, the block/batch is skipped (like the standard
   version).
 - if a filter doesn't match, a block with all default values and `empty
   = true` is inserted to keep ordering between blocks.