### PR TITLE
sink: implement factory mode

### DIFF
--- a/core/src/filter.rs
+++ b/core/src/filter.rs
@@ -1,0 +1,7 @@
+use prost::Message;
+use serde::de::DeserializeOwned;
+
+pub trait Filter: Default + Message + Clone + DeserializeOwned {
+    /// Merges the given filter into this filter.
+    fn merge_filter(&mut self, other: Self);
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod filter;
 pub mod node;
 pub mod quota;
 pub mod starknet;

--- a/examples/common/jediswap.js
+++ b/examples/common/jediswap.js
@@ -1,0 +1,141 @@
+import { hash } from "https://esm.run/starknet@5.14";
+
+const PAIR_CREATED = selector("PairCreated");
+const UPGRADED = selector("Upgraded");
+const ADMIN_CHANGED = selector("AdminChanged");
+const BURN = selector("Burn");
+const MINT = selector("Mint");
+const SWAP = selector("Swap");
+const SYNC = selector("Sync");
+const APPROVAL = selector("Approval");
+const TRANSFER = selector("Transfer");
+
+// Stream `PairCreated` events from JediSwap.
+export const filter = {
+  header: { weak: true },
+  events: [
+    {
+      fromAddress:
+        "0x00dad44c139a476c7a17fc8141e6db680e9abc9f56fe249a105094c44382c2fd",
+      keys: [PAIR_CREATED],
+      includeReceipt: false,
+    },
+  ],
+};
+
+// Export a `factory` function to enable factory mode.
+// This function is called with data from the `filter` above
+// and returns a filter that is used to stream child data.
+// Filters from subsequent calls to `factory` are merged.
+export function factory({ header, events }) {
+  // Create a filter with events for all pools created in this block.
+  const poolEvents = events.flatMap(({ event }) => {
+    const pairAddress = event.data[2];
+    return [
+      UPGRADED,
+      ADMIN_CHANGED,
+      BURN,
+      MINT,
+      SWAP,
+      SYNC,
+      APPROVAL,
+      TRANSFER,
+    ].map((eventKey) => ({
+      fromAddress: pairAddress,
+      keys: [eventKey],
+      includeReceipt: false,
+    }));
+  });
+
+  // Insert data about the pools created in this block.
+  // Values returned in `data` are handled like values returned from
+  // `transform`.
+  const pools = events.flatMap(({ event, transaction }) => {
+    const token0 = event.data[0];
+    const token1 = event.data[1];
+    const pairAddress = event.data[2];
+    return {
+      type: "PairCreated",
+      createdAt: header.timestamp,
+      createdAtBlockNumber: +header.blockNumber,
+      createdAtTxHash: transaction.meta.hash,
+      poolId: pairAddress,
+      token0Id: token0,
+      token1Id: token1,
+    };
+  });
+
+  return {
+    filter: {
+      header: { weak: true },
+      events: poolEvents,
+    },
+    data: pools,
+  };
+}
+
+// The transform function is invoked with data from the child filter
+// created by the factory function above.
+export function transform({ header, events }) {
+  return events.flatMap(({ event, transaction }) => {
+    const txMeta = {
+      pairId: event.fromAddress,
+      createdAt: header.timestamp,
+      createdAtBlockNumber: +header.blockNumber,
+      createdAtTxHash: transaction.meta.hash,
+    };
+
+    switch (event.keys[0]) {
+      case UPGRADED:
+        return {
+          type: "Upgraded",
+          ...txMeta,
+        };
+      case ADMIN_CHANGED:
+        return {
+          type: "AdminChanged",
+          ...txMeta,
+        };
+      case BURN:
+        return {
+          type: "Burn",
+          ...txMeta,
+        };
+      case MINT:
+        return {
+          type: "Mint",
+          ...txMeta,
+        };
+      case SWAP:
+        return {
+          type: "Swap",
+          ...txMeta,
+        };
+      case SYNC:
+        return {
+          type: "Sync",
+          ...txMeta,
+        };
+      case APPROVAL:
+        return {
+          type: "Approval",
+          ...txMeta,
+        };
+      case TRANSFER:
+        return {
+          type: "Transfer",
+          ...txMeta,
+        };
+      default:
+        console.log("UNKNOWN");
+        return [];
+    }
+  });
+}
+
+// Pad selector to match DNA felt length.
+function selector(name) {
+  const bn = BigInt(hash.getSelectorFromName(name));
+  const padded = bn.toString(16).padStart(64, "0");
+  return "0x" + padded;
+}

--- a/examples/console/starknet_factory.js
+++ b/examples/console/starknet_factory.js
@@ -1,0 +1,15 @@
+import { filter, transform } from "../common/jediswap.js";
+
+export { factory } from "../common/jediswap.js";
+
+export const config = {
+  // streamUrl: "https://mainnet.starknet.a5a.ch",
+  streamUrl: "http://localhost:7171",
+  startingBlock: 486_000,
+  network: "starknet",
+  filter,
+  sinkType: "console",
+  sinkOptions: {},
+};
+
+export default transform;

--- a/examples/parquet/starknet_factory.js
+++ b/examples/parquet/starknet_factory.js
@@ -1,0 +1,21 @@
+import { filter, transform } from "../common/jediswap.js";
+
+export { factory } from "../common/jediswap.js";
+
+export const config = {
+  // streamUrl: "https://mainnet.starknet.a5a.ch",
+  streamUrl: "http://localhost:7171",
+  startingBlock: 486_000,
+  network: "starknet",
+  filter,
+  sinkType: "parquet",
+  sinkOptions: {
+    // Files will have data for 100 blocks each.
+    // In reality, you want this number to be higher (like 1_000),
+    // but for the sake of this example, we keep it low to generate
+    // files quickly.
+    batchSize: 100,
+  },
+};
+
+export default transform;


### PR DESCRIPTION
**Summary**
This PR introduces factory mode. Developers can export a `factory`
callback from their script to enable this mode.

The `filter` returned by the `factory` callback is used to create the
"main" data stream, whose transformed output is passed to the
integration.

This commit is not concerned with correctly handling cursor and state
persistence between restarts, or combining the main filter.