### PR TITLE
sink: adjust retry behaviour

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-console"
-version = "0.3.8"
+version = "0.4.0"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-mongo"
-version = "0.4.10"
+version = "0.5.0"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-parquet"
-version = "0.3.8"
+version = "0.4.0"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-postgres"
-version = "0.4.10"
+version = "0.5.0"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-webhook"
-version = "0.3.8"
+version = "0.4.0"
 dependencies = [
  "apibara-core",
  "apibara-observability",

--- a/sinks/sink-console/CHANGELOG.md
+++ b/sinks/sink-console/CHANGELOG.md
@@ -6,14 +6,33 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2024-01-13
+
+_Introduce factory mode to dynamically update the stream filter._
+
+### Added
+
+-   Introduce factory mode. Use this to dynamically update the stream filter, for
+    example to start receiving data from a smart contract deployed by another smart
+    contract. Enable factory mode by exporting a `factory` function from your script.
+-   The sink now emits OpenTelemetry metrics to track the sync status.
+
+### Changed
+
+-   The status response from the status server now includes the chain's head.
+
+### Fixed
+
+-   Fixed an issue with the status server response timing out during the initial sync.
+
 ## [0.3.8] - 2023-12-02
 
 _Index data in a specific block range._
 
 ### Added
 
- - Add a new `--ending-block` (`endingBlock` if configured from the script)
-   option to stop the indexer at a specific block.
+-   Add a new `--ending-block` (`endingBlock` if configured from the script)
+    option to stop the indexer at a specific block.
 
 ## [0.3.7] - 2023-11-30
 
@@ -21,9 +40,9 @@ _Control indexer timeouts._
 
 ### Added
 
- - Add new `--script-load-timeout-seconds` and
-   `--script-transform-timeout-seconds` options to control the maximum time the
-   indexer script has to initialize and transform data respectively.
+-   Add new `--script-load-timeout-seconds` and
+    `--script-transform-timeout-seconds` options to control the maximum time the
+    indexer script has to initialize and transform data respectively.
 
 ## [0.3.6] - 2023-11-16
 
@@ -31,14 +50,14 @@ _Add new environment-related options._
 
 ### Added
 
- - Add new `--allow-env-from-env` flag to allow the indexer script to access
- the parent process environment variables. Users can pass a list of
- comma-separated variables to this option.
+-   Add new `--allow-env-from-env` flag to allow the indexer script to access
+    the parent process environment variables. Users can pass a list of
+    comma-separated variables to this option.
 
 ### Changed
 
- - Cleanup the default logs to only show the current block number.
- - To restore the previous, more detailed logs, set the log level to debug.
+-   Cleanup the default logs to only show the current block number.
+-   To restore the previous, more detailed logs, set the log level to debug.
 
 ## [0.3.5] - 2023-11-11
 
@@ -46,28 +65,28 @@ _Fix an issue on Linux._
 
 ### Fixed
 
- - Link against GLIBC 3.5. The most recent build was linking against GLIBC 3.8
-   which caused some issues on non-rolling release distributions.
+-   Link against GLIBC 3.5. The most recent build was linking against GLIBC 3.8
+    which caused some issues on non-rolling release distributions.
 
 ## [0.3.4] - 2023-11-07
 
-_Improve performance for data-heavy indexers._ 
+_Improve performance for data-heavy indexers._
 
 ### Added
 
- - Update Starknet's event filter to support the new `includeTransaction`,
-   and `includeReceipt` options. These options control whether the server will
-   send the transaction and/or receipt that generated an event. For indexers
-   that don't need this data, toggling this option on can improve performance
-   drastically.
+-   Update Starknet's event filter to support the new `includeTransaction`,
+    and `includeReceipt` options. These options control whether the server will
+    send the transaction and/or receipt that generated an event. For indexers
+    that don't need this data, toggling this option on can improve performance
+    drastically.
 
 ### Changed
 
- - Update the Deno runtime to `deno_core v0.244` and `deno_runtime v0.130`.
- - Use the new
-   [`#[op2]`](https://docs.rs/deno_core/0.224.0/deno_core/attr.op2.html) macro
-   to exchange data between Deno and Rust. Data serialization and
-   deserialization between the sink and the script is now faster.
+-   Update the Deno runtime to `deno_core v0.244` and `deno_runtime v0.130`.
+-   Use the new
+    [`#[op2]`](https://docs.rs/deno_core/0.224.0/deno_core/attr.op2.html) macro
+    to exchange data between Deno and Rust. Data serialization and
+    deserialization between the sink and the script is now faster.
 
 ## [0.3.3] - 2023-10-27
 
@@ -75,9 +94,9 @@ _Fix exit code on disconnect._
 
 ### Fixed
 
- - In some cases, the sink would exit with a `0` exit code on error. This
-   version ensures that the sink will return a non-zero exit code on all
-   errors.
+-   In some cases, the sink would exit with a `0` exit code on error. This
+    version ensures that the sink will return a non-zero exit code on all
+    errors.
 
 ## [0.3.2] - 2023-10-24
 
@@ -85,12 +104,12 @@ _Error message improvements._
 
 ### Changed
 
- - This version changes how errors are handled to improve error messages.
-   Errors now show more context and additional information that will help
-   developers debug their indexers.
- - The sink will return a non-zero error code on failure. We use the standard
-   unix exit codes in `sysexit.h`. Developers can use exit codes to decide
-   whether to restart the indexer or not.
+-   This version changes how errors are handled to improve error messages.
+    Errors now show more context and additional information that will help
+    developers debug their indexers.
+-   The sink will return a non-zero error code on failure. We use the standard
+    unix exit codes in `sysexit.h`. Developers can use exit codes to decide
+    whether to restart the indexer or not.
 
 ## [0.3.1] - 2023-10-11
 
@@ -98,10 +117,9 @@ _Disconnect when stream hangs._
 
 ### Added
 
- - Add a new `--timeout-duration-seconds` flag to control the timeout between
-   stream messages. If the stream doesn't receive any message in this interval,
-   the sink exits. Defaults to 45 seconds.
-
+-   Add a new `--timeout-duration-seconds` flag to control the timeout between
+    stream messages. If the stream doesn't receive any message in this interval,
+    the sink exits. Defaults to 45 seconds.
 
 ## [0.3.0] - 2023-09-16
 
@@ -109,11 +127,11 @@ _Introduce sink status gRPC service._
 
 ### Changed
 
- - The status server is now a gRPC service. This service returns the sink
-   indexing status, the starting block, and the chain's current head block
-   from the upstream DNA service. 
- - The status server now binds on a random port. This means it's easier to run
-   multiple sinks at the same time.
+-   The status server is now a gRPC service. This service returns the sink
+    indexing status, the starting block, and the chain's current head block
+    from the upstream DNA service.
+-   The status server now binds on a random port. This means it's easier to run
+    multiple sinks at the same time.
 
 ## [0.2.0] - 2023-08-21
 
@@ -121,21 +139,20 @@ _This release improves the developer experience when running locally._
 
 ### Added
 
- - Add a `--persist-to-fs=my-dir` flag to persist the indexer's state to the
-   filesystem. This option creates a new directory (specified by the user) and
-   writes the indexer's current state to a file, with one file per indexer.
-   Developers shouldn't use this option for production, but only for
-   development since it lacks any locking mechanism to prevent multiple copies
-   of the same indexer running at the same time.
+-   Add a `--persist-to-fs=my-dir` flag to persist the indexer's state to the
+    filesystem. This option creates a new directory (specified by the user) and
+    writes the indexer's current state to a file, with one file per indexer.
+    Developers shouldn't use this option for production, but only for
+    development since it lacks any locking mechanism to prevent multiple copies
+    of the same indexer running at the same time.
 
 ### Changed
 
- - The transform function now is invoked with a single block of data.
+-   The transform function now is invoked with a single block of data.
 
 ## [0.1.0] - 2023-08-08
 
 _First tagged release 🎉_
-
 
 [0.3.8]: https://github.com/apibara/dna/releases/tag/sink-console/v0.3.8
 [0.3.7]: https://github.com/apibara/dna/releases/tag/sink-console/v0.3.7

--- a/sinks/sink-console/Cargo.toml
+++ b/sinks/sink-console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-console"
-version = "0.3.8"
+version = "0.4.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-mongo/CHANGELOG.md
+++ b/sinks/sink-mongo/CHANGELOG.md
@@ -6,14 +6,33 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2024-01-13
+
+_Introduce factory mode to dynamically update the stream filter._
+
+### Added
+
+-   Introduce factory mode. Use this to dynamically update the stream filter, for
+    example to start receiving data from a smart contract deployed by another smart
+    contract. Enable factory mode by exporting a `factory` function from your script.
+-   The sink now emits OpenTelemetry metrics to track the sync status.
+
+### Changed
+
+-   The status response from the status server now includes the chain's head.
+
+### Fixed
+
+-   Fixed an issue with the status server response timing out during the initial sync.
+
 ## [0.4.10] - 2023-12-02
 
 _Index data in a specific block range._
 
 ### Added
 
- - Add a new `--ending-block` (`endingBlock` if configured from the script)
-   option to stop the indexer at a specific block.
+-   Add a new `--ending-block` (`endingBlock` if configured from the script)
+    option to stop the indexer at a specific block.
 
 ## [0.4.9] - 2023-11-30
 
@@ -21,9 +40,9 @@ _Control indexer timeouts._
 
 ### Added
 
- - Add new `--script-load-timeout-seconds` and
-   `--script-transform-timeout-seconds` options to control the maximum time the
-   indexer script has to initialize and transform data respectively.
+-   Add new `--script-load-timeout-seconds` and
+    `--script-transform-timeout-seconds` options to control the maximum time the
+    indexer script has to initialize and transform data respectively.
 
 ## [0.4.8] - 2023-11-29
 
@@ -31,13 +50,13 @@ _Write to multiple collections from one indexer._
 
 ### Added
 
- - Add a new option to write to multiple collections from a single indexer.
-   Change `collectionName` to `collectionNames` and specify a list of
-   collections. When multi collection mode is enabled, the transform function
-   return value changes. The transform must return data with the following type
-   `{ collection: string, data: T }[]`, that is data together with the
-   collection where to insert it. Refer to the documentation to learn more about
-   multi collection mode.
+-   Add a new option to write to multiple collections from a single indexer.
+    Change `collectionName` to `collectionNames` and specify a list of
+    collections. When multi collection mode is enabled, the transform function
+    return value changes. The transform must return data with the following type
+    `{ collection: string, data: T }[]`, that is data together with the
+    collection where to insert it. Refer to the documentation to learn more about
+    multi collection mode.
 
 ## [0.4.7] - 2023-11-16
 
@@ -45,14 +64,14 @@ _Add new environment-related options._
 
 ### Added
 
- - Add new `--allow-env-from-env` flag to allow the indexer script to access
- the parent process environment variables. Users can pass a list of
- comma-separated variables to this option.
+-   Add new `--allow-env-from-env` flag to allow the indexer script to access
+    the parent process environment variables. Users can pass a list of
+    comma-separated variables to this option.
 
 ### Changed
 
- - Cleanup the default logs to only show the current block number.
- - To restore the previous, more detailed logs, set the log level to debug.
+-   Cleanup the default logs to only show the current block number.
+-   To restore the previous, more detailed logs, set the log level to debug.
 
 ## [0.4.6] - 2023-11-11
 
@@ -60,8 +79,8 @@ _Fix an issue on Linux._
 
 ### Fixed
 
- - Link against GLIBC 3.5. The most recent build was linking against GLIBC 3.8
-   which caused some issues on non-rolling release distributions.
+-   Link against GLIBC 3.5. The most recent build was linking against GLIBC 3.8
+    which caused some issues on non-rolling release distributions.
 
 ## [0.4.5] - 2023-11-09
 
@@ -69,30 +88,30 @@ _Write to the same collection from multiple indexers._
 
 ### Added
 
- - Add a new `invalidate` option used to add additional conditions to the
-   invalidate query. Developers can constrain which documents are delete by an
-   indexer on data invalidation, so that multiple indexers can write to the
-   same collection.
+-   Add a new `invalidate` option used to add additional conditions to the
+    invalidate query. Developers can constrain which documents are delete by an
+    indexer on data invalidation, so that multiple indexers can write to the
+    same collection.
 
 ## [0.4.4] - 2023-11-07
 
-_Improve performance for data-heavy indexers._ 
+_Improve performance for data-heavy indexers._
 
 ### Added
 
- - Update Starknet's event filter to support the new `includeTransaction`,
-   and `includeReceipt` options. These options control whether the server will
-   send the transaction and/or receipt that generated an event. For indexers
-   that don't need this data, toggling this option on can improve performance
-   drastically.
+-   Update Starknet's event filter to support the new `includeTransaction`,
+    and `includeReceipt` options. These options control whether the server will
+    send the transaction and/or receipt that generated an event. For indexers
+    that don't need this data, toggling this option on can improve performance
+    drastically.
 
 ### Changed
 
- - Update the Deno runtime to `deno_core v0.244` and `deno_runtime v0.130`.
- - Use the new
-   [`#[op2]`](https://docs.rs/deno_core/0.224.0/deno_core/attr.op2.html) macro
-   to exchange data between Deno and Rust. Data serialization and
-   deserialization between the sink and the script is now faster.
+-   Update the Deno runtime to `deno_core v0.244` and `deno_runtime v0.130`.
+-   Use the new
+    [`#[op2]`](https://docs.rs/deno_core/0.224.0/deno_core/attr.op2.html) macro
+    to exchange data between Deno and Rust. Data serialization and
+    deserialization between the sink and the script is now faster.
 
 ## [0.4.3] - 2023-10-27
 
@@ -100,9 +119,9 @@ _Fix exit code on disconnect._
 
 ### Fixed
 
- - In some cases, the sink would exit with a `0` exit code on error. This
-   version ensures that the sink will return a non-zero exit code on all
-   errors.
+-   In some cases, the sink would exit with a `0` exit code on error. This
+    version ensures that the sink will return a non-zero exit code on all
+    errors.
 
 ## [0.4.2] - 2023-10-24
 
@@ -110,12 +129,12 @@ _Error message improvements._
 
 ### Changed
 
- - This version changes how errors are handled to improve error messages.
-   Errors now show more context and additional information that will help
-   developers debug their indexers.
- - The sink will return a non-zero error code on failure. We use the standard
-   unix exit codes in `sysexit.h`. Developers can use exit codes to decide
-   whether to restart the indexer or not.
+-   This version changes how errors are handled to improve error messages.
+    Errors now show more context and additional information that will help
+    developers debug their indexers.
+-   The sink will return a non-zero error code on failure. We use the standard
+    unix exit codes in `sysexit.h`. Developers can use exit codes to decide
+    whether to restart the indexer or not.
 
 ## [0.4.1] - 2023-10-11
 
@@ -123,10 +142,9 @@ _Disconnect when stream hangs._
 
 ### Added
 
- - Add a new `--timeout-duration-seconds` flag to control the timeout between
-   stream messages. If the stream doesn't receive any message in this interval,
-   the sink exits. Defaults to 45 seconds.
-
+-   Add a new `--timeout-duration-seconds` flag to control the timeout between
+    stream messages. If the stream doesn't receive any message in this interval,
+    the sink exits. Defaults to 45 seconds.
 
 ## [0.4.0] - 2023-09-16
 
@@ -134,12 +152,11 @@ _Introduce sink status gRPC service._
 
 ### Changed
 
- - The status server is now a gRPC service. This service returns the sink
-   indexing status, the starting block, and the chain's current head block
-   from the upstream DNA service. 
- - The status server now binds on a random port. This means it's easier to run
-   multiple sinks at the same time.
-
+-   The status server is now a gRPC service. This service returns the sink
+    indexing status, the starting block, and the chain's current head block
+    from the upstream DNA service.
+-   The status server now binds on a random port. This means it's easier to run
+    multiple sinks at the same time.
 
 ## [0.3.0] - 2023-08-29
 
@@ -147,12 +164,12 @@ _Introduce entity mode to index stateful entities._
 
 ### Added
 
- - Add _entity mode_ to index stateful entities. When this mode is turned on
-   (by setting the `entityMode` option to `true`), the indexer behaviour changes
-   to enable updating entities while indexing.
-   The return value of the transform is expected to be a list of `{ entity, update }`
-   objects, where `update` is a MongoDB update document or pipeline.
-   Please refer to the document to read more about entity mode.
+-   Add _entity mode_ to index stateful entities. When this mode is turned on
+    (by setting the `entityMode` option to `true`), the indexer behaviour changes
+    to enable updating entities while indexing.
+    The return value of the transform is expected to be a list of `{ entity, update }`
+    objects, where `update` is a MongoDB update document or pipeline.
+    Please refer to the document to read more about entity mode.
 
 ## [0.2.0] - 2023-08-21
 
@@ -160,23 +177,22 @@ _This release improves the developer experience when running locally._
 
 ### Added
 
- - Add a `--persist-to-fs=my-dir` flag to persist the indexer's state to the
-   filesystem. This option creates a new directory (specified by the user) and
-   writes the indexer's current state to a file, with one file per indexer.
-   Developers shouldn't use this option for production, but only for
-   development since it lacks any locking mechanism to prevent multiple copies
-   of the same indexer running at the same time.
+-   Add a `--persist-to-fs=my-dir` flag to persist the indexer's state to the
+    filesystem. This option creates a new directory (specified by the user) and
+    writes the indexer's current state to a file, with one file per indexer.
+    Developers shouldn't use this option for production, but only for
+    development since it lacks any locking mechanism to prevent multiple copies
+    of the same indexer running at the same time.
 
 ### Changed
 
- - The transform function now is invoked with a single block of data.
- Batching is a low-level mechanism used to control how often data is written to Mongo,
- but it shouldn't affect the transform step.
+-   The transform function now is invoked with a single block of data.
+    Batching is a low-level mechanism used to control how often data is written to Mongo,
+    but it shouldn't affect the transform step.
 
 ## [0.1.0] - 2023-08-08
 
 _First tagged release 🎉_
-
 
 [0.4.10]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.4.10
 [0.4.9]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.4.9

--- a/sinks/sink-mongo/Cargo.toml
+++ b/sinks/sink-mongo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-mongo"
-version = "0.4.10"
+version = "0.5.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-parquet/CHANGELOG.md
+++ b/sinks/sink-parquet/CHANGELOG.md
@@ -6,14 +6,33 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2024-01-13
+
+_Introduce factory mode to dynamically update the stream filter._
+
+### Added
+
+-   Introduce factory mode. Use this to dynamically update the stream filter, for
+    example to start receiving data from a smart contract deployed by another smart
+    contract. Enable factory mode by exporting a `factory` function from your script.
+-   The sink now emits OpenTelemetry metrics to track the sync status.
+
+### Changed
+
+-   The status response from the status server now includes the chain's head.
+
+### Fixed
+
+-   Fixed an issue with the status server response timing out during the initial sync.
+
 ## [0.3.8] - 2023-12-02
 
 _Index data in a specific block range._
 
 ### Added
 
- - Add a new `--ending-block` (`endingBlock` if configured from the script)
-   option to stop the indexer at a specific block.
+-   Add a new `--ending-block` (`endingBlock` if configured from the script)
+    option to stop the indexer at a specific block.
 
 ## [0.3.7] - 2023-11-30
 
@@ -21,9 +40,9 @@ _Control indexer timeouts._
 
 ### Added
 
- - Add new `--script-load-timeout-seconds` and
-   `--script-transform-timeout-seconds` options to control the maximum time the
-   indexer script has to initialize and transform data respectively.
+-   Add new `--script-load-timeout-seconds` and
+    `--script-transform-timeout-seconds` options to control the maximum time the
+    indexer script has to initialize and transform data respectively.
 
 ## [0.3.6] - 2023-11-16
 
@@ -31,14 +50,14 @@ _Add new environment-related options._
 
 ### Added
 
- - Add new `--allow-env-from-env` flag to allow the indexer script to access
- the parent process environment variables. Users can pass a list of
- comma-separated variables to this option.
+-   Add new `--allow-env-from-env` flag to allow the indexer script to access
+    the parent process environment variables. Users can pass a list of
+    comma-separated variables to this option.
 
 ### Changed
 
- - Cleanup the default logs to only show the current block number.
- - To restore the previous, more detailed logs, set the log level to debug.
+-   Cleanup the default logs to only show the current block number.
+-   To restore the previous, more detailed logs, set the log level to debug.
 
 ## [0.3.5] - 2023-11-11
 
@@ -46,28 +65,28 @@ _Fix an issue on Linux._
 
 ### Fixed
 
- - Link against GLIBC 3.5. The most recent build was linking against GLIBC 3.8
-   which caused some issues on non-rolling release distributions.
+-   Link against GLIBC 3.5. The most recent build was linking against GLIBC 3.8
+    which caused some issues on non-rolling release distributions.
 
 ## [0.3.4] - 2023-11-07
 
-_Improve performance for data-heavy indexers._ 
+_Improve performance for data-heavy indexers._
 
 ### Added
 
- - Update Starknet's event filter to support the new `includeTransaction`,
-   and `includeReceipt` options. These options control whether the server will
-   send the transaction and/or receipt that generated an event. For indexers
-   that don't need this data, toggling this option on can improve performance
-   drastically.
+-   Update Starknet's event filter to support the new `includeTransaction`,
+    and `includeReceipt` options. These options control whether the server will
+    send the transaction and/or receipt that generated an event. For indexers
+    that don't need this data, toggling this option on can improve performance
+    drastically.
 
 ### Changed
 
- - Update the Deno runtime to `deno_core v0.244` and `deno_runtime v0.130`.
- - Use the new
-   [`#[op2]`](https://docs.rs/deno_core/0.224.0/deno_core/attr.op2.html) macro
-   to exchange data between Deno and Rust. Data serialization and
-   deserialization between the sink and the script is now faster.
+-   Update the Deno runtime to `deno_core v0.244` and `deno_runtime v0.130`.
+-   Use the new
+    [`#[op2]`](https://docs.rs/deno_core/0.224.0/deno_core/attr.op2.html) macro
+    to exchange data between Deno and Rust. Data serialization and
+    deserialization between the sink and the script is now faster.
 
 ## [0.3.3] - 2023-10-27
 
@@ -75,9 +94,9 @@ _Fix exit code on disconnect._
 
 ### Fixed
 
- - In some cases, the sink would exit with a `0` exit code on error. This
-   version ensures that the sink will return a non-zero exit code on all
-   errors.
+-   In some cases, the sink would exit with a `0` exit code on error. This
+    version ensures that the sink will return a non-zero exit code on all
+    errors.
 
 ## [0.3.2] - 2023-10-24
 
@@ -85,12 +104,12 @@ _Error message improvements._
 
 ### Changed
 
- - This version changes how errors are handled to improve error messages.
-   Errors now show more context and additional information that will help
-   developers debug their indexers.
- - The sink will return a non-zero error code on failure. We use the standard
-   unix exit codes in `sysexit.h`. Developers can use exit codes to decide
-   whether to restart the indexer or not.
+-   This version changes how errors are handled to improve error messages.
+    Errors now show more context and additional information that will help
+    developers debug their indexers.
+-   The sink will return a non-zero error code on failure. We use the standard
+    unix exit codes in `sysexit.h`. Developers can use exit codes to decide
+    whether to restart the indexer or not.
 
 ## [0.3.1] - 2023-10-11
 
@@ -98,10 +117,9 @@ _Disconnect when stream hangs._
 
 ### Added
 
- - Add a new `--timeout-duration-seconds` flag to control the timeout between
-   stream messages. If the stream doesn't receive any message in this interval,
-   the sink exits. Defaults to 45 seconds.
-
+-   Add a new `--timeout-duration-seconds` flag to control the timeout between
+    stream messages. If the stream doesn't receive any message in this interval,
+    the sink exits. Defaults to 45 seconds.
 
 ## [0.3.0] - 2023-09-16
 
@@ -109,11 +127,11 @@ _Introduce sink status gRPC service._
 
 ### Changed
 
- - The status server is now a gRPC service. This service returns the sink
-   indexing status, the starting block, and the chain's current head block
-   from the upstream DNA service. 
- - The status server now binds on a random port. This means it's easier to run
-   multiple sinks at the same time.
+-   The status server is now a gRPC service. This service returns the sink
+    indexing status, the starting block, and the chain's current head block
+    from the upstream DNA service.
+-   The status server now binds on a random port. This means it's easier to run
+    multiple sinks at the same time.
 
 ## [0.2.0] - 2023-08-21
 
@@ -121,21 +139,20 @@ _This release improves the developer experience when running locally._
 
 ### Added
 
- - Add a `--persist-to-fs=my-dir` flag to persist the indexer's state to the
-   filesystem. This option creates a new directory (specified by the user) and
-   writes the indexer's current state to a file, with one file per indexer.
-   Developers shouldn't use this option for production, but only for
-   development since it lacks any locking mechanism to prevent multiple copies
-   of the same indexer running at the same time.
+-   Add a `--persist-to-fs=my-dir` flag to persist the indexer's state to the
+    filesystem. This option creates a new directory (specified by the user) and
+    writes the indexer's current state to a file, with one file per indexer.
+    Developers shouldn't use this option for production, but only for
+    development since it lacks any locking mechanism to prevent multiple copies
+    of the same indexer running at the same time.
 
 ### Changed
 
- - The transform function now is invoked with a single block of data.
+-   The transform function now is invoked with a single block of data.
 
 ## [0.1.0] - 2023-08-08
 
 _First tagged release 🎉_
-
 
 [0.3.8]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.3.8
 [0.3.7]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.3.7

--- a/sinks/sink-parquet/Cargo.toml
+++ b/sinks/sink-parquet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-parquet"
-version = "0.3.8"
+version = "0.4.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
@@ -18,11 +18,18 @@ path = "src/bin.rs"
 apibara-core = { path = "../../core" }
 apibara-observability = { path = "../../observability" }
 apibara-sink-common = { path = "../sink-common" }
-arrow = { version = "41.0.0", default-features = false, features = ["arrow-json", "json"] }
+arrow = { version = "41.0.0", default-features = false, features = [
+    "arrow-json",
+    "json",
+] }
 async-trait.workspace = true
 error-stack.workspace = true
 clap.workspace = true
-parquet = { version = "41.0.0", default-features = false, features = ["arrow", "arrow-array", "arrow-schema"] }
+parquet = { version = "41.0.0", default-features = false, features = [
+    "arrow",
+    "arrow-array",
+    "arrow-schema",
+] }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/sinks/sink-postgres/CHANGELOG.md
+++ b/sinks/sink-postgres/CHANGELOG.md
@@ -6,23 +6,43 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2024-01-13
+
+_Introduce factory mode to dynamically update the stream filter._
+
+### Added
+
+-   Introduce factory mode. Use this to dynamically update the stream filter, for
+    example to start receiving data from a smart contract deployed by another smart
+    contract. Enable factory mode by exporting a `factory` function from your script.
+-   The sink now emits OpenTelemetry metrics to track the sync status.
+
+### Changed
+
+-   The status response from the status server now includes the chain's head.
+
+### Fixed
+
+-   Fixed an issue with the status server response timing out during the initial sync.
+
 ## [0.4.10] - 2023-12-02
 
 _Index data in a specific block range._
 
 ### Added
 
- - Add a new `--ending-block` (`endingBlock` if configured from the script)
-   option to stop the indexer at a specific block.
+-   Add a new `--ending-block` (`endingBlock` if configured from the script)
+    option to stop the indexer at a specific block.
+
 ## [0.4.9] - 2023-11-30
 
 _Control indexer timeouts._
 
 ### Added
 
- - Add new `--script-load-timeout-seconds` and
-   `--script-transform-timeout-seconds` options to control the maximum time the
-   indexer script has to initialize and transform data respectively.
+-   Add new `--script-load-timeout-seconds` and
+    `--script-transform-timeout-seconds` options to control the maximum time the
+    indexer script has to initialize and transform data respectively.
 
 ## [0.4.8] - 2023-11-27
 
@@ -30,10 +50,10 @@ _Store entities state._
 
 ### Added
 
- - Add a new `entityMode` option to enable entity mode. In entity mode,
-   indexers can insert and update stateful entities (like account balances or
-   token ownership). Please refer to the documentation and examples to learn
-   more about entity mode.
+-   Add a new `entityMode` option to enable entity mode. In entity mode,
+    indexers can insert and update stateful entities (like account balances or
+    token ownership). Please refer to the documentation and examples to learn
+    more about entity mode.
 
 ## [0.4.7] - 2023-11-16
 
@@ -41,14 +61,14 @@ _Add new environment-related options._
 
 ### Added
 
- - Add new `--allow-env-from-env` flag to allow the indexer script to access
- the parent process environment variables. Users can pass a list of
- comma-separated variables to this option.
+-   Add new `--allow-env-from-env` flag to allow the indexer script to access
+    the parent process environment variables. Users can pass a list of
+    comma-separated variables to this option.
 
 ### Changed
 
- - Cleanup the default logs to only show the current block number.
- - To restore the previous, more detailed logs, set the log level to debug.
+-   Cleanup the default logs to only show the current block number.
+-   To restore the previous, more detailed logs, set the log level to debug.
 
 ## [0.4.6] - 2023-11-11
 
@@ -56,28 +76,28 @@ _Fix an issue on Linux._
 
 ### Fixed
 
- - Link against GLIBC 3.5. The most recent build was linking against GLIBC 3.8
-   which caused some issues on non-rolling release distributions.
+-   Link against GLIBC 3.5. The most recent build was linking against GLIBC 3.8
+    which caused some issues on non-rolling release distributions.
 
 ## [0.4.5] - 2023-11-07
 
-_Improve performance for data-heavy indexers._ 
+_Improve performance for data-heavy indexers._
 
 ### Added
 
- - Update Starknet's event filter to support the new `includeTransaction`,
-   and `includeReceipt` options. These options control whether the server will
-   send the transaction and/or receipt that generated an event. For indexers
-   that don't need this data, toggling this option on can improve performance
-   drastically.
+-   Update Starknet's event filter to support the new `includeTransaction`,
+    and `includeReceipt` options. These options control whether the server will
+    send the transaction and/or receipt that generated an event. For indexers
+    that don't need this data, toggling this option on can improve performance
+    drastically.
 
 ### Changed
 
- - Update the Deno runtime to `deno_core v0.244` and `deno_runtime v0.130`.
- - Use the new
-   [`#[op2]`](https://docs.rs/deno_core/0.224.0/deno_core/attr.op2.html) macro
-   to exchange data between Deno and Rust. Data serialization and
-   deserialization between the sink and the script is now faster.
+-   Update the Deno runtime to `deno_core v0.244` and `deno_runtime v0.130`.
+-   Use the new
+    [`#[op2]`](https://docs.rs/deno_core/0.224.0/deno_core/attr.op2.html) macro
+    to exchange data between Deno and Rust. Data serialization and
+    deserialization between the sink and the script is now faster.
 
 ## [0.4.4] - 2023-11-06
 
@@ -85,10 +105,10 @@ _Write to the same table from multiple indexers._
 
 ### Added
 
- - Add a new `invalidate` option used to add additional conditions to the
-   invalidate query. Developers can constrain which rows are delete by an
-   indexer on data invalidation, so that multiple indexers can write to the
-   same table.
+-   Add a new `invalidate` option used to add additional conditions to the
+    invalidate query. Developers can constrain which rows are delete by an
+    indexer on data invalidation, so that multiple indexers can write to the
+    same table.
 
 ## [0.4.3] - 2023-10-27
 
@@ -96,9 +116,9 @@ _Fix exit code on disconnect._
 
 ### Fixed
 
- - In some cases, the sink would exit with a `0` exit code on error. This
-   version ensures that the sink will return a non-zero exit code on all
-   errors.
+-   In some cases, the sink would exit with a `0` exit code on error. This
+    version ensures that the sink will return a non-zero exit code on all
+    errors.
 
 ## [0.4.2] - 2023-10-24
 
@@ -106,12 +126,12 @@ _Error message improvements._
 
 ### Changed
 
- - This version changes how errors are handled to improve error messages.
-   Errors now show more context and additional information that will help
-   developers debug their indexers.
- - The sink will return a non-zero error code on failure. We use the standard
-   unix exit codes in `sysexit.h`. Developers can use exit codes to decide
-   whether to restart the indexer or not.
+-   This version changes how errors are handled to improve error messages.
+    Errors now show more context and additional information that will help
+    developers debug their indexers.
+-   The sink will return a non-zero error code on failure. We use the standard
+    unix exit codes in `sysexit.h`. Developers can use exit codes to decide
+    whether to restart the indexer or not.
 
 ## [0.4.1] - 2023-10-11
 
@@ -119,10 +139,9 @@ _Disconnect when stream hangs._
 
 ### Added
 
- - Add a new `--timeout-duration-seconds` flag to control the timeout between
-   stream messages. If the stream doesn't receive any message in this interval,
-   the sink exits. Defaults to 45 seconds.
-
+-   Add a new `--timeout-duration-seconds` flag to control the timeout between
+    stream messages. If the stream doesn't receive any message in this interval,
+    the sink exits. Defaults to 45 seconds.
 
 ## [0.4.0] - 2023-09-16
 
@@ -130,11 +149,11 @@ _Introduce sink status gRPC service._
 
 ### Changed
 
- - The status server is now a gRPC service. This service returns the sink
-   indexing status, the starting block, and the chain's current head block
-   from the upstream DNA service. 
- - The status server now binds on a random port. This means it's easier to run
-   multiple sinks at the same time.
+-   The status server is now a gRPC service. This service returns the sink
+    indexing status, the starting block, and the chain's current head block
+    from the upstream DNA service.
+-   The status server now binds on a random port. This means it's easier to run
+    multiple sinks at the same time.
 
 ## [0.3.0] - 2023-09-11
 
@@ -142,16 +161,15 @@ _Bring support for TLS connections._
 
 ### Changed
 
- - **Breaking**: use TLS by default. You can revert to the old insecure
-   connection by using the `--no-tls=true` CLI flag, or setting
-   `sinkOptions.noTls: true` in your script.
+-   **Breaking**: use TLS by default. You can revert to the old insecure
+    connection by using the `--no-tls=true` CLI flag, or setting
+    `sinkOptions.noTls: true` in your script.
 
 ### Added
 
- - You can now connect to PostgreSQL securely using TLS connections. The TLS
-   connection can be customized by providing a self-signed certificate, or by
-   enabling/disabling certificate and hostname validation.
-
+-   You can now connect to PostgreSQL securely using TLS connections. The TLS
+    connection can be customized by providing a self-signed certificate, or by
+    enabling/disabling certificate and hostname validation.
 
 ## [0.2.0] - 2023-08-21
 
@@ -159,23 +177,22 @@ _This release improves the developer experience when running locally._
 
 ### Added
 
- - Add a `--persist-to-fs=my-dir` flag to persist the indexer's state to the
-   filesystem. This option creates a new directory (specified by the user) and
-   writes the indexer's current state to a file, with one file per indexer.
-   Developers shouldn't use this option for production, but only for
-   development since it lacks any locking mechanism to prevent multiple copies
-   of the same indexer running at the same time.
+-   Add a `--persist-to-fs=my-dir` flag to persist the indexer's state to the
+    filesystem. This option creates a new directory (specified by the user) and
+    writes the indexer's current state to a file, with one file per indexer.
+    Developers shouldn't use this option for production, but only for
+    development since it lacks any locking mechanism to prevent multiple copies
+    of the same indexer running at the same time.
 
 ### Changed
 
- - The transform function now is invoked with a single block of data.
- Batching is a low-level mechanism used to control how often data is written to Postgres,
- but it shouldn't affect the transform step.
+-   The transform function now is invoked with a single block of data.
+    Batching is a low-level mechanism used to control how often data is written to Postgres,
+    but it shouldn't affect the transform step.
 
 ## [0.1.0] - 2023-08-08
 
 _First tagged release 🎉_
-
 
 [0.4.10]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.4.10
 [0.4.9]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.4.9

--- a/sinks/sink-postgres/Cargo.toml
+++ b/sinks/sink-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-postgres"
-version = "0.4.10"
+version = "0.5.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
@@ -35,4 +35,3 @@ jemallocator.workspace = true
 
 [dev-dependencies]
 testcontainers.workspace = true
-

--- a/sinks/sink-webhook/CHANGELOG.md
+++ b/sinks/sink-webhook/CHANGELOG.md
@@ -6,14 +6,33 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2024-01-13
+
+_Introduce factory mode to dynamically update the stream filter._
+
+### Added
+
+-   Introduce factory mode. Use this to dynamically update the stream filter, for
+    example to start receiving data from a smart contract deployed by another smart
+    contract. Enable factory mode by exporting a `factory` function from your script.
+-   The sink now emits OpenTelemetry metrics to track the sync status.
+
+### Changed
+
+-   The status response from the status server now includes the chain's head.
+
+### Fixed
+
+-   Fixed an issue with the status server response timing out during the initial sync.
+
 ## [0.3.8] - 2023-12-02
 
 _Index data in a specific block range._
 
 ### Added
 
- - Add a new `--ending-block` (`endingBlock` if configured from the script)
-   option to stop the indexer at a specific block.
+-   Add a new `--ending-block` (`endingBlock` if configured from the script)
+    option to stop the indexer at a specific block.
 
 ## [0.3.7] - 2023-11-30
 
@@ -21,9 +40,9 @@ _Control indexer timeouts._
 
 ### Added
 
- - Add new `--script-load-timeout-seconds` and
-   `--script-transform-timeout-seconds` options to control the maximum time the
-   indexer script has to initialize and transform data respectively.
+-   Add new `--script-load-timeout-seconds` and
+    `--script-transform-timeout-seconds` options to control the maximum time the
+    indexer script has to initialize and transform data respectively.
 
 ## [0.3.6] - 2023-11-16
 
@@ -31,14 +50,14 @@ _Add new environment-related options._
 
 ### Added
 
- - Add new `--allow-env-from-env` flag to allow the indexer script to access
- the parent process environment variables. Users can pass a list of
- comma-separated variables to this option.
+-   Add new `--allow-env-from-env` flag to allow the indexer script to access
+    the parent process environment variables. Users can pass a list of
+    comma-separated variables to this option.
 
 ### Changed
 
- - Cleanup the default logs to only show the current block number.
- - To restore the previous, more detailed logs, set the log level to debug.
+-   Cleanup the default logs to only show the current block number.
+-   To restore the previous, more detailed logs, set the log level to debug.
 
 ## [0.3.5] - 2023-11-11
 
@@ -46,28 +65,28 @@ _Fix an issue on Linux._
 
 ### Fixed
 
- - Link against GLIBC 3.5. The most recent build was linking against GLIBC 3.8
-   which caused some issues on non-rolling release distributions.
+-   Link against GLIBC 3.5. The most recent build was linking against GLIBC 3.8
+    which caused some issues on non-rolling release distributions.
 
 ## [0.3.4] - 2023-11-07
 
-_Improve performance for data-heavy indexers._ 
+_Improve performance for data-heavy indexers._
 
 ### Added
 
- - Update Starknet's event filter to support the new `includeTransaction`,
-   and `includeReceipt` options. These options control whether the server will
-   send the transaction and/or receipt that generated an event. For indexers
-   that don't need this data, toggling this option on can improve performance
-   drastically.
+-   Update Starknet's event filter to support the new `includeTransaction`,
+    and `includeReceipt` options. These options control whether the server will
+    send the transaction and/or receipt that generated an event. For indexers
+    that don't need this data, toggling this option on can improve performance
+    drastically.
 
 ### Changed
 
- - Update the Deno runtime to `deno_core v0.244` and `deno_runtime v0.130`.
- - Use the new
-   [`#[op2]`](https://docs.rs/deno_core/0.224.0/deno_core/attr.op2.html) macro
-   to exchange data between Deno and Rust. Data serialization and
-   deserialization between the sink and the script is now faster.
+-   Update the Deno runtime to `deno_core v0.244` and `deno_runtime v0.130`.
+-   Use the new
+    [`#[op2]`](https://docs.rs/deno_core/0.224.0/deno_core/attr.op2.html) macro
+    to exchange data between Deno and Rust. Data serialization and
+    deserialization between the sink and the script is now faster.
 
 ## [0.3.3] - 2023-10-27
 
@@ -75,9 +94,9 @@ _Fix exit code on disconnect._
 
 ### Fixed
 
- - In some cases, the sink would exit with a `0` exit code on error. This
-   version ensures that the sink will return a non-zero exit code on all
-   errors.
+-   In some cases, the sink would exit with a `0` exit code on error. This
+    version ensures that the sink will return a non-zero exit code on all
+    errors.
 
 ## [0.3.2] - 2023-10-24
 
@@ -85,12 +104,12 @@ _Error message improvements._
 
 ### Changed
 
- - This version changes how errors are handled to improve error messages.
-   Errors now show more context and additional information that will help
-   developers debug their indexers.
- - The sink will return a non-zero error code on failure. We use the standard
-   unix exit codes in `sysexit.h`. Developers can use exit codes to decide
-   whether to restart the indexer or not.
+-   This version changes how errors are handled to improve error messages.
+    Errors now show more context and additional information that will help
+    developers debug their indexers.
+-   The sink will return a non-zero error code on failure. We use the standard
+    unix exit codes in `sysexit.h`. Developers can use exit codes to decide
+    whether to restart the indexer or not.
 
 ## [0.3.1] - 2023-10-11
 
@@ -98,10 +117,9 @@ _Disconnect when stream hangs._
 
 ### Added
 
- - Add a new `--timeout-duration-seconds` flag to control the timeout between
-   stream messages. If the stream doesn't receive any message in this interval,
-   the sink exits. Defaults to 45 seconds.
-
+-   Add a new `--timeout-duration-seconds` flag to control the timeout between
+    stream messages. If the stream doesn't receive any message in this interval,
+    the sink exits. Defaults to 45 seconds.
 
 ## [0.3.0] - 2023-09-16
 
@@ -109,11 +127,11 @@ _Introduce sink status gRPC service._
 
 ### Changed
 
- - The status server is now a gRPC service. This service returns the sink
-   indexing status, the starting block, and the chain's current head block
-   from the upstream DNA service. 
- - The status server now binds on a random port. This means it's easier to run
-   multiple sinks at the same time.
+-   The status server is now a gRPC service. This service returns the sink
+    indexing status, the starting block, and the chain's current head block
+    from the upstream DNA service.
+-   The status server now binds on a random port. This means it's easier to run
+    multiple sinks at the same time.
 
 ## [0.2.0] - 2023-08-21
 
@@ -121,24 +139,22 @@ _This release improves the developer experience when running locally._
 
 ### Added
 
- - Add a `--persist-to-fs=my-dir` flag to persist the indexer's state to the
-   filesystem. This option creates a new directory (specified by the user) and
-   writes the indexer's current state to a file, with one file per indexer.
-   Developers shouldn't use this option for production, but only for
-   development since it lacks any locking mechanism to prevent multiple copies
-   of the same indexer running at the same time.
+-   Add a `--persist-to-fs=my-dir` flag to persist the indexer's state to the
+    filesystem. This option creates a new directory (specified by the user) and
+    writes the indexer's current state to a file, with one file per indexer.
+    Developers shouldn't use this option for production, but only for
+    development since it lacks any locking mechanism to prevent multiple copies
+    of the same indexer running at the same time.
 
 ### Changed
 
- - The transform function now is invoked with a single block of data.
- - In "raw mode", each value returned by the transform function is sent as an
-   individual request.
-
+-   The transform function now is invoked with a single block of data.
+-   In "raw mode", each value returned by the transform function is sent as an
+    individual request.
 
 ## [0.1.0] - 2023-08-08
 
 _First tagged release 🎉_
-
 
 [0.3.8]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.3.8
 [0.3.7]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.3.7

--- a/sinks/sink-webhook/Cargo.toml
+++ b/sinks/sink-webhook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-webhook"
-version = "0.3.8"
+version = "0.4.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
sink: adjust retry behaviour

**Summary**
Reduce the wait time between retries to a minute at most. Ensure that
the indexer exits for all non-temporary errors.

release: sink-{console, mongo, parquet, postgres, webhook}

**Summary**
sink-console: v0.4.0
sink-mongo: v0.5.0
sink-parquet: v0.4.0
sink-postgres: v0.5.0
sink-webhook: v0.4.0