### PR TITLE
sink-postgres: reconnect if client becomes disconnected

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-postgres"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "apibara-core",
  "apibara-observability",

--- a/sinks/sink-postgres/CHANGELOG.md
+++ b/sinks/sink-postgres/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2024-01-14
+
+_Reconnect client on disconnect._
+
+### Fixed
+
+-   Ensure that the client is connected before running any query. If the client
+    is not connected, reconnects to it.
+
 ## [0.5.0] - 2024-01-13
 
 _Introduce factory mode to dynamically update the stream filter._

--- a/sinks/sink-postgres/Cargo.toml
+++ b/sinks/sink-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-postgres"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
sink-postgres: reconnect if client becomes disconnected

**Summary**
When running for long periods of time (like in production), the client
may disconnect from the server. This causes all queries to fail and the
indexer to be stuck ~30m until it restarts.
This commit ensures that the client is connected before executing a
query.

release: sink-postgres

**Summary**
sink-postgres: v0.5.1