### PR TITLE
sink: add flag to allow network access

### DIFF
--- a/script/src/script.rs
+++ b/script/src/script.rs
@@ -43,6 +43,10 @@ pub struct ScriptOptions {
     ///
     /// An empty list gives access to _ALL_ environment variables.
     pub allow_env: Option<Vec<String>>,
+    /// Allow network access to the given hosts.
+    ///
+    /// An empty list gives access to _ALL_ hosts.
+    pub allow_net: Option<Vec<String>>,
     /// Maximum time allowed to execute the transform function.
     pub transform_timeout: Option<Duration>,
     /// Maximum time allowed to load the indexer script.
@@ -353,6 +357,7 @@ impl Script {
         match Permissions::from_options(&PermissionsOptions {
             allow_env: options.allow_env.clone(),
             allow_hrtime: true,
+            allow_net: options.allow_net.clone(),
             prompt: false,
             ..PermissionsOptions::default()
         }) {

--- a/sinks/sink-common/src/configuration.rs
+++ b/sinks/sink-common/src/configuration.rs
@@ -77,6 +77,11 @@ pub struct ScriptOptions {
     /// Grant access to the specified environment variables.
     #[arg(long, env, value_delimiter = ',')]
     pub allow_env_from_env: Option<Vec<String>>,
+    /// Grant network access to the hosts.
+    ///
+    /// Leave empty to allow all hosts, i.e. by specifying `--allow-net`.
+    #[arg(long, env, value_delimiter = ',', num_args = 0..)]
+    pub allow_net: Option<Vec<String>>,
     /// Maximum time allowed to execute the transform function.
     #[arg(long, env)]
     pub script_transform_timeout_seconds: Option<u64>,
@@ -356,6 +361,7 @@ impl ScriptOptions {
     pub fn into_indexer_options(self) -> IndexerOptions {
         IndexerOptions {
             allow_env: self.allow_env_from_env,
+            allow_net: self.allow_net,
             transform_timeout: self
                 .script_transform_timeout_seconds
                 .map(Duration::from_secs),

--- a/sinks/sink-console/src/bin.rs
+++ b/sinks/sink-console/src/bin.rs
@@ -34,7 +34,7 @@ struct RunArgs {
     common: OptionsFromCli,
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> ExitCode {
     let args = Cli::parse();
     run_with_args(args).await.to_exit_code()

--- a/sinks/sink-mongo/src/bin.rs
+++ b/sinks/sink-mongo/src/bin.rs
@@ -34,7 +34,7 @@ struct RunArgs {
     common: OptionsFromCli,
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> ExitCode {
     let args = Cli::parse();
     run_with_args(args).await.to_exit_code()

--- a/sinks/sink-parquet/src/bin.rs
+++ b/sinks/sink-parquet/src/bin.rs
@@ -34,7 +34,7 @@ struct RunArgs {
     common: OptionsFromCli,
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> ExitCode {
     let args = Cli::parse();
     run_with_args(args).await.to_exit_code()

--- a/sinks/sink-postgres/src/bin.rs
+++ b/sinks/sink-postgres/src/bin.rs
@@ -34,7 +34,7 @@ struct RunArgs {
     common: OptionsFromCli,
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> ExitCode {
     let args = Cli::parse();
     run_with_args(args).await.to_exit_code()

--- a/sinks/sink-webhook/src/bin.rs
+++ b/sinks/sink-webhook/src/bin.rs
@@ -34,7 +34,7 @@ struct RunArgs {
     common: OptionsFromCli,
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> ExitCode {
     let args = Cli::parse();
     run_with_args(args).await.to_exit_code()


### PR DESCRIPTION
**Summary**
More complex indexers require users to interact with external APIs.
It's time to let indexers communicate with the external world.