### PR TITLE
sink-parquet: multiple datasets from one indexer

### DIFF
--- a/examples/parquet/starknet_factory.js
+++ b/examples/parquet/starknet_factory.js
@@ -1,10 +1,11 @@
-import { filter, transform } from "../common/jediswap.js";
-
-export { factory } from "../common/jediswap.js";
+import {
+  filter,
+  transform as jediswapTransform,
+  factory as jediswapFactory,
+} from "../common/jediswap.js";
 
 export const config = {
-  // streamUrl: "https://mainnet.starknet.a5a.ch",
-  streamUrl: "http://localhost:7171",
+  streamUrl: "https://mainnet.starknet.a5a.ch",
   startingBlock: 486_000,
   network: "starknet",
   filter,
@@ -15,7 +16,39 @@ export const config = {
     // but for the sake of this example, we keep it low to generate
     // files quickly.
     batchSize: 100,
+    // Create multiple datasets with one indexer.
+    datasets: [
+      "PairCreated",
+      "Upgraded",
+      "AdminChanged",
+      "Burn",
+      "Mint",
+      "Swap",
+      "Sync",
+      "Approval",
+      "Transfer",
+    ],
   },
 };
 
-export default transform;
+export function factory({ header, events }) {
+  const { filter, data } = jediswapFactory({ header, events });
+
+  const datasets = data.map((data) => ({
+    dataset: "PairCreated",
+    data,
+  }));
+
+  return {
+    filter,
+    data: datasets,
+  };
+}
+
+export default function transform({ header, events }) {
+  // Dataset names can be dynamic.
+  return jediswapTransform({ header, events }).map((data) => ({
+    dataset: data.type,
+    data,
+  }));
+}

--- a/sinks/sink-parquet/src/configuration.rs
+++ b/sinks/sink-parquet/src/configuration.rs
@@ -10,6 +10,7 @@ use crate::sink::SinkParquetError;
 pub struct SinkParquetConfiguration {
     pub output_dir: PathBuf,
     pub batch_size: usize,
+    pub datasets: Option<Vec<String>>,
 }
 
 #[derive(Debug, Args, Default, SinkOptions)]
@@ -21,6 +22,11 @@ pub struct SinkParquetOptions {
     /// The batch size to use when writing parquet files.
     #[arg(long, env = "PARQUET_BATCH_SIZE")]
     pub batch_size: Option<usize>,
+    /// Output multiple datasets.
+    ///
+    /// Datasets are organized in subdirectories of the output directory.
+    #[arg(long, env = "PARQUET_DATASETS", value_delimiter = ',')]
+    pub datasets: Option<Vec<String>>,
 }
 
 impl SinkOptions for SinkParquetOptions {
@@ -28,6 +34,7 @@ impl SinkOptions for SinkParquetOptions {
         Self {
             output_dir: self.output_dir.or(other.output_dir),
             batch_size: self.batch_size.or(other.batch_size),
+            datasets: self.datasets.or(other.datasets),
         }
     }
 }
@@ -46,6 +53,7 @@ impl SinkParquetOptions {
         Ok(SinkParquetConfiguration {
             output_dir,
             batch_size,
+            datasets: self.datasets,
         })
     }
 }


### PR DESCRIPTION
**Summary**
Add a new option to write to multiple datasets with one indexer.