### PR TITLE
release: sink-{console, mongo, parquet, postgres, webhook}

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-console"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-mongo"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-parquet"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-postgres"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-webhook"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "apibara-core",
  "apibara-observability",

--- a/sinks/sink-console/CHANGELOG.md
+++ b/sinks/sink-console/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2024-01-16
+
+_Enable network access._
+
+### Added
+
+-   Indexers can now access the network to make HTTP/TCP calls. Use the
+    `--allow-net` flag without arguments to allow connecting to any address, or
+    restrict access to selected domains by specifying the domains as comma-separated
+    values.
+
 ## [0.4.0] - 2024-01-13
 
 _Introduce factory mode to dynamically update the stream filter._
@@ -154,6 +165,8 @@ _This release improves the developer experience when running locally._
 
 _First tagged release 🎉_
 
+[0.4.1]: https://github.com/apibara/dna/releases/tag/sink-console/v0.4.1
+[0.4.0]: https://github.com/apibara/dna/releases/tag/sink-console/v0.4.0
 [0.3.8]: https://github.com/apibara/dna/releases/tag/sink-console/v0.3.8
 [0.3.7]: https://github.com/apibara/dna/releases/tag/sink-console/v0.3.7
 [0.3.6]: https://github.com/apibara/dna/releases/tag/sink-console/v0.3.6

--- a/sinks/sink-console/Cargo.toml
+++ b/sinks/sink-console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-console"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-mongo/CHANGELOG.md
+++ b/sinks/sink-mongo/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2024-01-16
+
+_Enable network access._
+
+### Added
+
+-   Indexers can now access the network to make HTTP/TCP calls. Use the `--allow-net` flag without arguments to allow connecting to any address, or restrict access to selected domains by specifying the domains as comma-separated values.
+
 ## [0.5.0] - 2024-01-13
 
 _Introduce factory mode to dynamically update the stream filter._
@@ -194,6 +202,8 @@ _This release improves the developer experience when running locally._
 
 _First tagged release 🎉_
 
+[0.5.1]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.5.1
+[0.5.0]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.5.0
 [0.4.10]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.4.10
 [0.4.9]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.4.9
 [0.4.8]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.4.8

--- a/sinks/sink-mongo/Cargo.toml
+++ b/sinks/sink-mongo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-mongo"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-parquet/CHANGELOG.md
+++ b/sinks/sink-parquet/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2024-01-16
+
+_Enable network access and multiple datasets generation._
+
+### Added
+
+-   Indexers can now access the network to make HTTP/TCP calls. Use the
+    `--allow-net` flag without arguments to allow connecting to any address, or
+    restrict access to selected domains by specifying the domains as comma-separated
+    values.
+
+### Changed
+
+-   Indexers can now generate multiple datasets. Specify the `datasets` you want
+    to generate in the `config`. The transform function can then return a list of
+    objects like `{ dataset: string, data: object }` to specify which dataset a
+    piece of data belongs to.
+
 ## [0.4.0] - 2024-01-13
 
 _Introduce factory mode to dynamically update the stream filter._
@@ -154,6 +172,8 @@ _This release improves the developer experience when running locally._
 
 _First tagged release 🎉_
 
+[0.4.1]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.4.1
+[0.4.0]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.4.0
 [0.3.8]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.3.8
 [0.3.7]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.3.7
 [0.3.6]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.3.6

--- a/sinks/sink-parquet/Cargo.toml
+++ b/sinks/sink-parquet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-parquet"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-postgres/CHANGELOG.md
+++ b/sinks/sink-postgres/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2024-01-16
+
+_Enable network access._
+
+### Added
+
+-   Indexers can now access the network to make HTTP/TCP calls. Use the
+    `--allow-net` flag without arguments to allow connecting to any address, or
+    restrict access to selected domains by specifying the domains as comma-separated
+    values.
+
 ## [0.5.1] - 2024-01-14
 
 _Reconnect client on disconnect._
@@ -203,6 +214,9 @@ _This release improves the developer experience when running locally._
 
 _First tagged release 🎉_
 
+[0.5.2]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.5.2
+[0.5.1]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.5.1
+[0.5.0]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.5.0
 [0.4.10]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.4.10
 [0.4.9]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.4.9
 [0.4.8]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.4.8

--- a/sinks/sink-postgres/Cargo.toml
+++ b/sinks/sink-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-postgres"
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-webhook/CHANGELOG.md
+++ b/sinks/sink-webhook/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2024-01-16
+
+_Enable network access._
+
+### Added
+
+-   Indexers can now access the network to make HTTP/TCP calls. Use the
+    `--allow-net` flag without arguments to allow connecting to any address, or
+    restrict access to selected domains by specifying the domains as comma-separated
+    values.
+
 ## [0.4.0] - 2024-01-13
 
 _Introduce factory mode to dynamically update the stream filter._
@@ -156,6 +167,8 @@ _This release improves the developer experience when running locally._
 
 _First tagged release 🎉_
 
+[0.4.1]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.4.1
+[0.4.0]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.4.0
 [0.3.8]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.3.8
 [0.3.7]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.3.7
 [0.3.6]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.3.6

--- a/sinks/sink-webhook/Cargo.toml
+++ b/sinks/sink-webhook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-webhook"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
**Summary**
sink-console: v0.4.1
sink-mongo: v0.5.1
sink-parquet: v0.4.1
sink-postgres: v0.5.2
sink-webhook: v0.4.1