### PR TITLE
Improve --allow-net flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "apibara-cli"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-console"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-mongo"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-parquet"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-postgres"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-webhook"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "apibara-core",
  "apibara-observability",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,13 +6,21 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2024-01-19
+
+_Allow network access._
+
+### Added
+
+-   Enable the `--allow-net` flag to allow the indexer script to access network resources.
+
 ## [0.4.1] - 2023-12-06
 
 _Improve compatibility with new sinks._
 
 ### Changed
 
- - Forward all environment-related options to the sink.
+-   Forward all environment-related options to the sink.
 
 ## [0.4.0] - 2023-11-10
 
@@ -20,8 +28,8 @@ _Update Starknet filter._
 
 ### Changed
 
- - Update the Starknet filter definition to support the new
-   `includeTransaction` and `includeReceipt` options.
+-   Update the Starknet filter definition to support the new
+    `includeTransaction` and `includeReceipt` options.
 
 ## [0.3.3] - 2023-10-25
 
@@ -29,9 +37,9 @@ _Minor quality of life improvements._
 
 ### Fixed
 
- - Don't attempt to install plugins (like sinks) from pre-release releases.
- - Show the correct plugin installation command when trying to run an indexer
-   that requires a missing sink.
+-   Don't attempt to install plugins (like sinks) from pre-release releases.
+-   Show the correct plugin installation command when trying to run an indexer
+    that requires a missing sink.
 
 ## [0.3.2] - 2023-10-24
 
@@ -39,9 +47,9 @@ _Error message improvements._
 
 ### Changed
 
- - This version changes how errors are handled to improve error messages.
-   Errors now show more context and additional information that will help
-   developers debug their indexers.
+-   This version changes how errors are handled to improve error messages.
+    Errors now show more context and additional information that will help
+    developers debug their indexers.
 
 ## [0.3.1] - 2023-10-17
 
@@ -49,8 +57,8 @@ _Minor bug fixes in the `apibara test` command._
 
 ### Fixed
 
- - Avoid storing sensitive information such as authentication tokens in the
-   test snapshots.
+-   Avoid storing sensitive information such as authentication tokens in the
+    test snapshots.
 
 ## [0.3.0] - 2023-09-26
 
@@ -58,15 +66,15 @@ _Add the `apibara test` command._
 
 ### Added
 
- - Introduce a `test` command to test indexers. This command implements
-   snapshot testing for indexers. The first time you run it, it downloads data
-   from a live DNA stream and records the output of the script. After the first
-   run, it replays the saved stream and compares the output from the script with
-   the output in the snapshot. A test is successful if the outputs match.
+-   Introduce a `test` command to test indexers. This command implements
+    snapshot testing for indexers. The first time you run it, it downloads data
+    from a live DNA stream and records the output of the script. After the first
+    run, it replays the saved stream and compares the output from the script with
+    the output in the snapshot. A test is successful if the outputs match.
 
 ### Changed
 
- - The `plugins` command is now also available as `plugin`.
+-   The `plugins` command is now also available as `plugin`.
 
 ## [0.2.0] - 2023-09-16
 
@@ -74,16 +82,15 @@ _Introduce sink status gRPC service._
 
 ### Changed
 
- - The status server is now a gRPC service. This service returns the sink
-   indexing status, the starting block, and the chain's current head block
-   from the upstream DNA service. 
- - The status server now binds on a random port. This means it's easier to run
-   multiple sinks at the same time.
+-   The status server is now a gRPC service. This service returns the sink
+    indexing status, the starting block, and the chain's current head block
+    from the upstream DNA service.
+-   The status server now binds on a random port. This means it's easier to run
+    multiple sinks at the same time.
 
 ## [0.1.0] - 2023-08-08
 
 _First tagged release 🎉_
-
 
 [0.4.0]: https://github.com/apibara/dna/releases/tag/cli/v0.4.0
 [0.3.3]: https://github.com/apibara/dna/releases/tag/cli/v0.3.3
@@ -92,4 +99,3 @@ _First tagged release 🎉_
 [0.3.0]: https://github.com/apibara/dna/releases/tag/cli/v0.3.0
 [0.2.0]: https://github.com/apibara/dna/releases/tag/cli/v0.2.0
 [0.1.0]: https://github.com/apibara/dna/releases/tag/cli/v0.1.0
-

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-cli"
-version = "0.4.1"
+version = "0.4.2"
 edition.workspace = true
 license.workspace = true
 
@@ -30,7 +30,9 @@ tar = "0.4.40"
 tokio.workspace = true
 tokio-util.workspace = true
 tokio-stream.workspace = true
-similar-asserts = { version = "1.4.2", features = ["serde"], git = "https://github.com/bigherc18/similar-asserts.git" }
+similar-asserts = { version = "1.4.2", features = [
+    "serde",
+], git = "https://github.com/bigherc18/similar-asserts.git" }
 walkdir = "2.3.3"
 tracing.workspace = true
 tempfile.workspace = true

--- a/cli/src/run.rs
+++ b/cli/src/run.rs
@@ -58,6 +58,10 @@ pub async fn run(args: RunArgs) -> Result<(), CliError> {
         extra_args.push("--allow-env-from-env".to_string());
         extra_args.push(allow_env_from_env.join(",").to_string());
     }
+    if let Some(allow_net) = args.transform.allow_net {
+        extra_args.push("--allow-net".to_string());
+        extra_args.push(allow_net.join(",").to_string());
+    };
     if let Some(transform_timeout) = args.transform.script_transform_timeout_seconds {
         extra_args.push("--script-transform-timeout-seconds".to_string());
         extra_args.push(transform_timeout.to_string());

--- a/script/src/script.rs
+++ b/script/src/script.rs
@@ -354,10 +354,23 @@ impl Script {
     }
 
     fn default_permissions(options: &ScriptOptions) -> Result<PermissionsContainer, ScriptError> {
+        // If users use an empty hostname, allow all hosts.
+        let allow_net = options.allow_net.clone().map(|hosts| {
+            if hosts.len() == 1 {
+                if hosts[0].is_empty() {
+                    vec![]
+                } else {
+                    hosts
+                }
+            } else {
+                hosts
+            }
+        });
+
         match Permissions::from_options(&PermissionsOptions {
             allow_env: options.allow_env.clone(),
             allow_hrtime: true,
-            allow_net: options.allow_net.clone(),
+            allow_net,
             prompt: false,
             ..PermissionsOptions::default()
         }) {

--- a/sinks/sink-console/CHANGELOG.md
+++ b/sinks/sink-console/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2024-01-19
+
+_Improve `--allow-net` flag usage._
+
+### Changed
+
+-   When the `--allow-net` flag is used and the value passed to it is an empty
+    string, treat it as equivalent to allowing any host. This is especially useful
+    if you're setting the flag with the `ALLOW_NET` environment variable.
+
 ## [0.4.1] - 2024-01-16
 
 _Enable network access._
@@ -165,6 +175,7 @@ _This release improves the developer experience when running locally._
 
 _First tagged release 🎉_
 
+[0.4.2]: https://github.com/apibara/dna/releases/tag/sink-console/v0.4.2
 [0.4.1]: https://github.com/apibara/dna/releases/tag/sink-console/v0.4.1
 [0.4.0]: https://github.com/apibara/dna/releases/tag/sink-console/v0.4.0
 [0.3.8]: https://github.com/apibara/dna/releases/tag/sink-console/v0.3.8

--- a/sinks/sink-console/Cargo.toml
+++ b/sinks/sink-console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-console"
-version = "0.4.1"
+version = "0.4.2"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-mongo/CHANGELOG.md
+++ b/sinks/sink-mongo/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2024-01-19
+
+_Improve `--allow-net` flag usage._
+
+### Changed
+
+-   When the `--allow-net` flag is used and the value passed to it is an empty
+    string, treat it as equivalent to allowing any host. This is especially useful
+    if you're setting the flag with the `ALLOW_NET` environment variable.
+
 ## [0.5.1] - 2024-01-16
 
 _Enable network access._
@@ -202,6 +212,7 @@ _This release improves the developer experience when running locally._
 
 _First tagged release 🎉_
 
+[0.5.2]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.5.2
 [0.5.1]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.5.1
 [0.5.0]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.5.0
 [0.4.10]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.4.10

--- a/sinks/sink-mongo/Cargo.toml
+++ b/sinks/sink-mongo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-mongo"
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-parquet/CHANGELOG.md
+++ b/sinks/sink-parquet/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2024-01-19
+
+_Improve `--allow-net` flag usage._
+
+### Changed
+
+-   When the `--allow-net` flag is used and the value passed to it is an empty
+    string, treat it as equivalent to allowing any host. This is especially useful
+    if you're setting the flag with the `ALLOW_NET` environment variable.
+
 ## [0.4.1] - 2024-01-16
 
 _Enable network access and multiple datasets generation._
@@ -172,6 +182,7 @@ _This release improves the developer experience when running locally._
 
 _First tagged release 🎉_
 
+[0.4.2]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.4.2
 [0.4.1]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.4.1
 [0.4.0]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.4.0
 [0.3.8]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.3.8

--- a/sinks/sink-parquet/Cargo.toml
+++ b/sinks/sink-parquet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-parquet"
-version = "0.4.1"
+version = "0.4.2"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-postgres/CHANGELOG.md
+++ b/sinks/sink-postgres/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3] - 2024-01-19
+
+_Improve `--allow-net` flag usage._
+
+### Changed
+
+-   When the `--allow-net` flag is used and the value passed to it is an empty
+    string, treat it as equivalent to allowing any host. This is especially useful
+    if you're setting the flag with the `ALLOW_NET` environment variable.
+
 ## [0.5.2] - 2024-01-16
 
 _Enable network access._
@@ -214,6 +224,7 @@ _This release improves the developer experience when running locally._
 
 _First tagged release 🎉_
 
+[0.5.3]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.5.3
 [0.5.2]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.5.2
 [0.5.1]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.5.1
 [0.5.0]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.5.0

--- a/sinks/sink-postgres/Cargo.toml
+++ b/sinks/sink-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-postgres"
-version = "0.5.2"
+version = "0.5.3"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-webhook/CHANGELOG.md
+++ b/sinks/sink-webhook/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2024-01-19
+
+_Improve `--allow-net` flag usage._
+
+### Changed
+
+-   When the `--allow-net` flag is used and the value passed to it is an empty
+    string, treat it as equivalent to allowing any host. This is especially useful
+    if you're setting the flag with the `ALLOW_NET` environment variable.
+
 ## [0.4.1] - 2024-01-16
 
 _Enable network access._
@@ -167,6 +177,7 @@ _This release improves the developer experience when running locally._
 
 _First tagged release 🎉_
 
+[0.4.2]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.4.2
 [0.4.1]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.4.1
 [0.4.0]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.4.0
 [0.3.8]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.3.8

--- a/sinks/sink-webhook/Cargo.toml
+++ b/sinks/sink-webhook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-webhook"
-version = "0.4.1"
+version = "0.4.2"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
cli: propagate --allow-net flag

sink: --allow-net="" allows any host

**Summary**
This change ensures that the --allow-net flag works in environments were
changing the command line arguments is not feasible/recommended (e.g.
docker containers).

Fix #312

release: cli, sink-{console, mongo, parquet, postgres, webhook}

**Summary**
cli: v0.4.2
sink-console: v0.4.2
sink-mongo: v0.5.2
sink-parquet: v0.4.2
sink-postgres: v0.5.3
sink-webhook: v0.4.2