### PR TITLE
sink: add redis persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,6 +411,7 @@ dependencies = [
  "futures 0.3.29",
  "lazy_static",
  "prost",
+ "redis",
  "regex",
  "serde",
  "serde_json",
@@ -1502,6 +1503,16 @@ dependencies = [
  "is-terminal",
  "lazy_static",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
+dependencies = [
+ "bytes 1.5.0",
+ "memchr",
 ]
 
 [[package]]
@@ -6276,6 +6287,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "redis"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c580d9cbbe1d1b479e8d67cf9daf6a62c957e6846048408b80b43ac3f6af84cd"
+dependencies = [
+ "combine",
+ "itoa",
+ "percent-encoding",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.4.10",
+ "url",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7117,6 +7143,12 @@ dependencies = [
  "cpufeatures",
  "digest 0.10.7",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"

--- a/sinks/sink-common/Cargo.toml
+++ b/sinks/sink-common/Cargo.toml
@@ -35,6 +35,7 @@ tokio-stream.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
 warp.workspace = true
+redis = "0.24.0"
 
 [dev-dependencies]
 assert_matches.workspace = true

--- a/sinks/sink-common/src/configuration.rs
+++ b/sinks/sink-common/src/configuration.rs
@@ -46,6 +46,9 @@ pub struct PersistenceTypeOptions {
     #[arg(long, env, requires = "sink_id")]
     /// Path to the directory used to persist data.
     pub persist_to_fs: Option<String>,
+    #[arg(long, env, requires = "sink_id")]
+    /// URL to the redis server used to persist data.
+    pub persist_to_redis: Option<String>,
 }
 
 /// Status server options.

--- a/sinks/sink-common/src/persistence/redis.rs
+++ b/sinks/sink-common/src/persistence/redis.rs
@@ -1,0 +1,84 @@
+use apibara_core::filter::Filter;
+use async_trait::async_trait;
+use error_stack::Result;
+use redis::Commands;
+use tracing::warn;
+
+use crate::{common::PersistenceClient, PersistedState, SinkError, SinkErrorResultExt};
+
+pub struct RedisPersistence {
+    client: redis::Client,
+    sink_id: String,
+}
+
+impl RedisPersistence {
+    pub async fn connect(
+        url: &str,
+        sink_id: impl Into<String>,
+    ) -> Result<RedisPersistence, SinkError> {
+        let client = redis::Client::open(url)
+            .persistence(&format!("failed to connect to redis server at {url}"))?;
+
+        Ok(RedisPersistence {
+            client,
+            sink_id: sink_id.into(),
+        })
+    }
+}
+
+#[async_trait]
+impl PersistenceClient for RedisPersistence {
+    async fn lock(&mut self) -> Result<(), SinkError> {
+        warn!("Locking is not yet supported for Redis persistence.");
+        Ok(())
+    }
+
+    async fn unlock(&mut self) -> Result<(), SinkError> {
+        warn!("Locking is not yet supported for Redis persistence.");
+        Ok(())
+    }
+
+    async fn get_state<F: Filter>(&mut self) -> Result<PersistedState<F>, SinkError> {
+        let mut conn = self
+            .client
+            .get_connection()
+            .persistence("failed to connect to redis")?;
+
+        let content = conn
+            .get::<_, Option<String>>(&self.sink_id)
+            .persistence("failed to get state from redis")?;
+
+        match content {
+            Some(content) => {
+                Ok(serde_json::from_str(&content).persistence("failed to deserialize state")?)
+            }
+            None => Ok(PersistedState::<F>::default()),
+        }
+    }
+
+    async fn put_state<F: Filter>(&mut self, state: PersistedState<F>) -> Result<(), SinkError> {
+        let mut conn = self
+            .client
+            .get_connection()
+            .persistence("failed to connect to redis")?;
+
+        let serialized = serde_json::to_string(&state).persistence("failed to serialize state")?;
+
+        conn.set(&self.sink_id, serialized)
+            .persistence("failed to put state in redis")?;
+
+        Ok(())
+    }
+
+    async fn delete_state(&mut self) -> Result<(), SinkError> {
+        let mut conn = self
+            .client
+            .get_connection()
+            .persistence("failed to connect to redis")?;
+
+        conn.del(&self.sink_id)
+            .persistence("failed to delete state from redis")?;
+
+        Ok(())
+    }
+}

--- a/sinks/sink-common/tests/test_redis_persistence.rs
+++ b/sinks/sink-common/tests/test_redis_persistence.rs
@@ -1,0 +1,90 @@
+mod common;
+
+use apibara_core::{node::v1alpha2::Cursor, starknet::v1alpha2::Filter};
+use apibara_sink_common::{
+    persistence::common::PersistenceClient, PersistedState, RedisPersistence,
+};
+use testcontainers::{clients, core::WaitFor, GenericImage};
+
+pub fn new_redis_image() -> GenericImage {
+    GenericImage::new("redis", "7-alpine")
+        .with_exposed_port(6379)
+        .with_wait_for(WaitFor::message_on_stdout(
+            "Ready to accept connections tcp",
+        ))
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_single_indexer() {
+    let docker = clients::Cli::default();
+    let redis = docker.run(new_redis_image());
+    let redis_port = redis.get_host_port_ipv4(6379);
+    let redis_url = format!("redis://localhost:{}", redis_port);
+
+    let mut persistence = RedisPersistence::connect(&redis_url, "test-sink")
+        .await
+        .unwrap();
+
+    let state = persistence.get_state::<Filter>().await.unwrap();
+    assert!(state.cursor.is_none());
+
+    let new_cursor = Cursor {
+        order_key: 123,
+        unique_key: vec![1, 2, 3],
+    };
+    let new_state = PersistedState::<Filter>::with_cursor(new_cursor.clone());
+
+    persistence.put_state(new_state).await.unwrap();
+    let state = persistence.get_state::<Filter>().await.unwrap();
+    assert_eq!(state.cursor, Some(new_cursor));
+
+    persistence.delete_state().await.unwrap();
+    let state = persistence.get_state::<Filter>().await.unwrap();
+    assert!(state.cursor.is_none());
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_multiple_indexers() {
+    let docker = clients::Cli::default();
+    let redis = docker.run(new_redis_image());
+    let redis_port = redis.get_host_port_ipv4(6379);
+    let redis_url = format!("redis://localhost:{}", redis_port);
+
+    let mut first = RedisPersistence::connect(&redis_url, "first-sink")
+        .await
+        .unwrap();
+
+    let mut second = RedisPersistence::connect(&redis_url, "second-sink")
+        .await
+        .unwrap();
+
+    let first_cursor = Cursor {
+        order_key: 123,
+        unique_key: vec![1, 2, 3],
+    };
+    let first_state = PersistedState::<Filter>::with_cursor(first_cursor.clone());
+
+    let second_cursor = Cursor {
+        order_key: 789,
+        unique_key: vec![7, 8, 9],
+    };
+    let second_state = PersistedState::<Filter>::with_cursor(second_cursor.clone());
+
+    first.put_state(first_state).await.unwrap();
+    let state = second.get_state::<Filter>().await.unwrap();
+    assert!(state.cursor.is_none());
+
+    second.put_state(second_state).await.unwrap();
+    let state = first.get_state::<Filter>().await.unwrap();
+    assert_eq!(state.cursor, Some(first_cursor));
+
+    first.delete_state().await.unwrap();
+    let state = second.get_state::<Filter>().await.unwrap();
+    assert_eq!(state.cursor, Some(second_cursor));
+
+    second.delete_state().await.unwrap();
+    let state = second.get_state::<Filter>().await.unwrap();
+    assert!(state.cursor.is_none());
+}


### PR DESCRIPTION
This PR adds redis persistence as an option.

Note that locking is not yet implemented since it's not that urgent

Fixes #314
