### PR TITLE
release: sink-{console, mongo, parquet, postgres, webhook}

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-console"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-mongo"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-parquet"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-postgres"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-webhook"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "apibara-core",
  "apibara-observability",

--- a/sinks/sink-console/CHANGELOG.md
+++ b/sinks/sink-console/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2024-01-25
+
+_Persist state to Redis._
+
+### Added
+
+-   You can now persist state to Redis! Use the `--persist-to-redis` flag with
+    [the connection string to your Redis
+    instance](https://docs.rs/redis/latest/redis/#connection-handling) and the sink
+    will store its state there. Data is persisted under the `apibara:sink:{sink_id}`
+    key and you can easily manage it with `redis-cli`.
+
 ## [0.4.2] - 2024-01-19
 
 _Improve `--allow-net` flag usage._
@@ -175,6 +187,7 @@ _This release improves the developer experience when running locally._
 
 _First tagged release 🎉_
 
+[0.4.3]: https://github.com/apibara/dna/releases/tag/sink-console/v0.4.3
 [0.4.2]: https://github.com/apibara/dna/releases/tag/sink-console/v0.4.2
 [0.4.1]: https://github.com/apibara/dna/releases/tag/sink-console/v0.4.1
 [0.4.0]: https://github.com/apibara/dna/releases/tag/sink-console/v0.4.0

--- a/sinks/sink-console/Cargo.toml
+++ b/sinks/sink-console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-console"
-version = "0.4.2"
+version = "0.4.3"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-mongo/CHANGELOG.md
+++ b/sinks/sink-mongo/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3] - 2024-01-25
+
+_Persist state to Redis._
+
+### Added
+
+-   You can now persist state to Redis! Use the `--persist-to-redis` flag with
+    [the connection string to your Redis
+    instance](https://docs.rs/redis/latest/redis/#connection-handling) and the sink
+    will store its state there. Data is persisted under the `apibara:sink:{sink_id}`
+    key and you can easily manage it with `redis-cli`.
+
 ## [0.5.2] - 2024-01-19
 
 _Improve `--allow-net` flag usage._
@@ -212,6 +224,7 @@ _This release improves the developer experience when running locally._
 
 _First tagged release 🎉_
 
+[0.5.3]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.5.3
 [0.5.2]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.5.2
 [0.5.1]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.5.1
 [0.5.0]: https://github.com/apibara/dna/releases/tag/sink-mongo/v0.5.0

--- a/sinks/sink-mongo/Cargo.toml
+++ b/sinks/sink-mongo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-mongo"
-version = "0.5.2"
+version = "0.5.3"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-parquet/CHANGELOG.md
+++ b/sinks/sink-parquet/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2024-01-25
+
+_Persist state to Redis._
+
+### Added
+
+-   You can now persist state to Redis! Use the `--persist-to-redis` flag with
+    [the connection string to your Redis
+    instance](https://docs.rs/redis/latest/redis/#connection-handling) and the sink
+    will store its state there. Data is persisted under the `apibara:sink:{sink_id}`
+    key and you can easily manage it with `redis-cli`.
+
 ## [0.4.2] - 2024-01-19
 
 _Improve `--allow-net` flag usage._
@@ -182,6 +194,7 @@ _This release improves the developer experience when running locally._
 
 _First tagged release 🎉_
 
+[0.4.3]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.4.3
 [0.4.2]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.4.2
 [0.4.1]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.4.1
 [0.4.0]: https://github.com/apibara/dna/releases/tag/sink-parquet/v0.4.0

--- a/sinks/sink-parquet/Cargo.toml
+++ b/sinks/sink-parquet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-parquet"
-version = "0.4.2"
+version = "0.4.3"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-postgres/CHANGELOG.md
+++ b/sinks/sink-postgres/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.4] - 2024-01-25
+
+_Persist state to Redis._
+
+### Added
+
+-   You can now persist state to Redis! Use the `--persist-to-redis` flag with
+    [the connection string to your Redis
+    instance](https://docs.rs/redis/latest/redis/#connection-handling) and the sink
+    will store its state there. Data is persisted under the `apibara:sink:{sink_id}`
+    key and you can easily manage it with `redis-cli`.
+
 ## [0.5.3] - 2024-01-19
 
 _Improve `--allow-net` flag usage._
@@ -224,6 +236,7 @@ _This release improves the developer experience when running locally._
 
 _First tagged release 🎉_
 
+[0.5.4]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.5.4
 [0.5.3]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.5.3
 [0.5.2]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.5.2
 [0.5.1]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.5.1

--- a/sinks/sink-postgres/Cargo.toml
+++ b/sinks/sink-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-postgres"
-version = "0.5.3"
+version = "0.5.4"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-webhook/CHANGELOG.md
+++ b/sinks/sink-webhook/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2024-01-25
+
+_Persist state to Redis._
+
+### Added
+
+-   You can now persist state to Redis! Use the `--persist-to-redis` flag with
+    [the connection string to your Redis
+    instance](https://docs.rs/redis/latest/redis/#connection-handling) and the sink
+    will store its state there. Data is persisted under the `apibara:sink:{sink_id}`
+    key and you can easily manage it with `redis-cli`.
+
 ## [0.4.2] - 2024-01-19
 
 _Improve `--allow-net` flag usage._
@@ -177,6 +189,7 @@ _This release improves the developer experience when running locally._
 
 _First tagged release 🎉_
 
+[0.4.3]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.4.3
 [0.4.2]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.4.2
 [0.4.1]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.4.1
 [0.4.0]: https://github.com/apibara/dna/releases/tag/sink-webhook/v0.4.0

--- a/sinks/sink-webhook/Cargo.toml
+++ b/sinks/sink-webhook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-webhook"
-version = "0.4.2"
+version = "0.4.3"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
**Summary**
sink-console: v0.4.3
sink-mongo: v0.5.3
sink-parquet: v0.4.3
sink-postgres: v0.5.4
sink-webhook: v0.4.3