### PR TITLE
parquet: support writing parquet files to S3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
  "futures 0.3.29",
  "futures-util",
  "hex",
- "http",
+ "http 0.2.9",
  "hyper 0.14.27",
  "pin-project",
  "prost",
@@ -497,6 +497,8 @@ dependencies = [
  "apibara-sink-common",
  "arrow",
  "async-trait",
+ "aws-config",
+ "aws-sdk-s3",
  "clap",
  "error-stack",
  "jemallocator",
@@ -541,7 +543,7 @@ dependencies = [
  "async-trait",
  "clap",
  "error-stack",
- "http",
+ "http 0.2.9",
  "jemallocator",
  "prost",
  "reqwest",
@@ -1011,6 +1013,387 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "aws-config"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91bb1df3e5f0e47475498570cdd10ab0370bc1d7af3151aa0161d5f5876b6908"
+dependencies = [
+ "aws-credential-types",
+ "aws-http",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes 1.5.0",
+ "fastrand 2.0.1",
+ "hex",
+ "http 0.2.9",
+ "hyper 0.14.27",
+ "ring 0.17.5",
+ "time",
+ "tokio 1.33.0",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d67c6836a1009b23e3f4cd1457c83e0aa49a490d9c3033b53c3f7b8cf2facc0f"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-http"
+version = "0.60.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a081f0c4576f7549dd255987d2d23920eccaa90cdd21d6440f91e0d7537f0e0d"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes 1.5.0",
+ "http 0.2.9",
+ "http-body 0.4.5",
+ "pin-project-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab7bf4b9b083e6dc86e2bb4fb09a4daca97e12cc0bc174a6f51fe624c23aa87f"
+dependencies = [
+ "aws-credential-types",
+ "aws-http",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "fastrand 2.0.1",
+ "http 0.2.9",
+ "percent-encoding",
+ "tracing",
+ "uuid 1.5.0",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f94d9842a304e066d1eddea61c703fb217ce5a1063cc087d07c8de1db4535f7"
+dependencies = [
+ "aws-credential-types",
+ "aws-http",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes 1.5.0",
+ "http 0.2.9",
+ "http-body 0.4.5",
+ "once_cell",
+ "percent-encoding",
+ "regex-lite",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "865b1b85249196e4868a48a4b6683d60e19b82371b869297bc9982bc9f47de4b"
+dependencies = [
+ "aws-credential-types",
+ "aws-http",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes 1.5.0",
+ "http 0.2.9",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beadaf5c48f5d923329ec87b7db6eea5e4ce2af4cc9f96d9f85d520f34573f40"
+dependencies = [
+ "aws-credential-types",
+ "aws-http",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes 1.5.0",
+ "http 0.2.9",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "262a6d40c8e11eea633ba541a39745cebfcee9c1683020cee63413048b5c6188"
+dependencies = [
+ "aws-credential-types",
+ "aws-http",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "http 0.2.9",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511879249616f30e30fd2fa81edb4833784f65dd5d56053b7de2e2bcb583dda7"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes 1.5.0",
+ "crypto-bigint 0.5.5",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.9",
+ "http 1.0.0",
+ "once_cell",
+ "p256 0.11.1",
+ "percent-encoding",
+ "ring 0.17.5",
+ "sha2",
+ "subtle",
+ "time",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ee2d09cce0ef3ae526679b522835d63e75fb427aca5413cd371e490d52dcc6"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio 1.33.0",
+]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.60.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2acd1b9c6ae5859999250ed5a62423aedc5cf69045b844432de15fa2f31f2b"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes 1.5.0",
+ "crc32c",
+ "crc32fast",
+ "hex",
+ "http 0.2.9",
+ "http-body 0.4.5",
+ "md-5",
+ "pin-project-lite",
+ "sha1",
+ "sha2",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6363078f927f612b970edf9d1903ef5cef9a64d1e8423525ebb1f0a1633c858"
+dependencies = [
+ "aws-smithy-types",
+ "bytes 1.5.0",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.60.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab56aea3cd9e1101a0a999447fb346afb680ab1406cebc44b32346e25b4117d"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes 1.5.0",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.9",
+ "http-body 0.4.5",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.60.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3898ca6518f9215f62678870064398f00031912390efd03f1f6ef56d83aa8e"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda4b1dfc9810e35fba8a620e900522cd1bd4f9578c446e82f49d1ce41d2e9f9"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fafdab38f40ad7816e7da5dec279400dd505160780083759f01441af1bbb10ea"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes 1.5.0",
+ "fastrand 2.0.1",
+ "h2",
+ "http 0.2.9",
+ "http-body 0.4.5",
+ "hyper 0.14.27",
+ "hyper-rustls",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "rustls",
+ "tokio 1.33.0",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c18276dd28852f34b3bf501f4f3719781f4999a51c7bff1a5c6dc8c4529adc29"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes 1.5.0",
+ "http 0.2.9",
+ "pin-project-lite",
+ "tokio 1.33.0",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb3e134004170d3303718baa2a4eb4ca64ee0a1c0a7041dca31b38be0fb414f3"
+dependencies = [
+ "base64-simd",
+ "bytes 1.5.0",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.9",
+ "http-body 0.4.5",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio 1.33.0",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8604a11b25e9ecaf32f9aa56b9fe253c5e2f606a3477f0071e96d3155a5ed218"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2739d97d47f47cdf0d27982019a405dcc736df25925d1a75049f1faa79df88"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 0.2.9",
+ "rustc_version 0.4.0",
+ "tracing",
+]
+
+[[package]]
 name = "axum"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,7 +1404,7 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes 1.5.0",
  "futures-util",
- "http",
+ "http 0.2.9",
  "http-body 0.4.5",
  "hyper 0.14.27",
  "itoa",
@@ -1047,7 +1430,7 @@ dependencies = [
  "async-trait",
  "bytes 1.5.0",
  "futures-util",
- "http",
+ "http 0.2.9",
  "http-body 0.4.5",
  "mime",
  "rustversion",
@@ -1341,6 +1724,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes 1.5.0",
+ "either",
+]
+
+[[package]]
 name = "bytesize"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1604,6 +1997,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32c"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f48d60e5b4d2c53d5c2b1d8a58c849a70ae5e5509b08a48d047e3b65714a74"
+dependencies = [
+ "rustc_version 0.4.0",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,9 +2101,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740fe28e594155f10cfc383984cbefd529d7396050557148f79cb0f621204124"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array 0.14.7",
  "rand_core 0.6.4",
@@ -2127,7 +2529,7 @@ dependencies = [
  "deno_core",
  "deno_tls",
  "dyn-clone",
- "http",
+ "http 0.2.9",
  "reqwest",
  "serde",
  "tokio 1.33.0",
@@ -2189,7 +2591,7 @@ dependencies = [
  "deno_websocket",
  "flate2",
  "fly-accept-encoding",
- "http",
+ "http 0.2.9",
  "httparse",
  "hyper 0.14.27",
  "hyper 1.0.0-rc.4",
@@ -2336,7 +2738,7 @@ dependencies = [
  "h2",
  "hex",
  "hkdf",
- "http",
+ "http 0.2.9",
  "idna 0.3.0",
  "indexmap 2.1.0",
  "lazy-regex",
@@ -2429,7 +2831,7 @@ dependencies = [
  "filetime",
  "fs3",
  "fwdansi",
- "http",
+ "http 0.2.9",
  "hyper 0.14.27",
  "libc",
  "log",
@@ -2536,7 +2938,7 @@ dependencies = [
  "deno_tls",
  "fastwebsockets",
  "h2",
- "http",
+ "http 0.2.9",
  "hyper 0.14.27",
  "once_cell",
  "rustls-tokio-stream",
@@ -2948,7 +3350,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d97ca172ae9dc9f9b779a6e3a65d308f2af74e5b8c921299075bdb4a0370e914"
 dependencies = [
  "base16ct 0.2.0",
- "crypto-bigint 0.5.3",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
  "ff 0.13.0",
  "generic-array 0.14.7",
@@ -3064,7 +3466,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4b0ea5ef6dc2388a4b1669fa32097249bc03a15417b97cb75e38afb309e4a89"
 dependencies = [
- "http",
+ "http 0.2.9",
  "prost",
  "tokio 1.33.0",
  "tokio-stream",
@@ -3280,7 +3682,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3afa7516fdcfd8e5e93a938f8fec857785ced190a1f62d842d1fe1ffbe22ba8"
 dependencies = [
- "http",
+ "http 0.2.9",
  "itertools",
  "thiserror",
 ]
@@ -3634,7 +4036,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.9",
  "indexmap 1.9.3",
  "slab",
  "tokio 1.33.0",
@@ -3693,7 +4095,7 @@ dependencies = [
  "base64 0.21.5",
  "bytes 1.5.0",
  "headers-core",
- "http",
+ "http 0.2.9",
  "httpdate",
  "mime",
  "sha1",
@@ -3705,7 +4107,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http",
+ "http 0.2.9",
 ]
 
 [[package]]
@@ -3779,13 +4181,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+dependencies = [
+ "bytes 1.5.0",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes 1.5.0",
- "http",
+ "http 0.2.9",
  "pin-project-lite",
 ]
 
@@ -3796,7 +4209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "951dfc2e32ac02d67c90c0d65bd27009a635dc9b381a2cc7d284ab01e3a0150d"
 dependencies = [
  "bytes 1.5.0",
- "http",
+ "http 0.2.9",
 ]
 
 [[package]]
@@ -3815,7 +4228,7 @@ dependencies = [
  "async-channel",
  "base64 0.13.1",
  "futures-lite",
- "http",
+ "http 0.2.9",
  "infer",
  "pin-project-lite",
  "rand 0.7.3",
@@ -3849,7 +4262,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.9",
  "http-body 0.4.5",
  "httparse",
  "httpdate",
@@ -3872,7 +4285,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.9",
  "http-body 1.0.0-rc.2",
  "httparse",
  "httpdate",
@@ -3890,7 +4303,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
+ "http 0.2.9",
  "hyper 0.14.27",
  "log",
  "rustls",
@@ -4229,7 +4642,7 @@ dependencies = [
  "base64 0.21.5",
  "bytes 1.5.0",
  "chrono",
- "http",
+ "http 0.2.9",
  "percent-encoding",
  "schemars",
  "serde",
@@ -4302,7 +4715,7 @@ dependencies = [
  "dirs-next",
  "either",
  "futures 0.3.29",
- "http",
+ "http 0.2.9",
  "http-body 0.4.5",
  "hyper 0.14.27",
  "hyper-rustls",
@@ -4334,7 +4747,7 @@ checksum = "f924177ad71936cfe612641b45bb9879890696d3c026f0846423529f4fa449af"
 dependencies = [
  "chrono",
  "form_urlencoded",
- "http",
+ "http 0.2.9",
  "json-patch",
  "k8s-openapi",
  "once_cell",
@@ -4898,7 +5311,7 @@ dependencies = [
  "bytes 1.5.0",
  "encoding_rs",
  "futures-util",
- "http",
+ "http 0.2.9",
  "httparse",
  "log",
  "memchr",
@@ -5189,7 +5602,7 @@ dependencies = [
  "either",
  "futures 0.3.29",
  "futures-util",
- "http",
+ "http 0.2.9",
  "http-body 0.4.5",
  "hyper 0.14.27",
  "hyper-rustls",
@@ -5295,7 +5708,7 @@ dependencies = [
  "async-trait",
  "futures 0.3.29",
  "futures-util",
- "http",
+ "http 0.2.9",
  "opentelemetry",
  "opentelemetry-proto",
  "prost",
@@ -6378,6 +6791,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b661b2f27137bdbc16f00eda72866a92bb28af1753ffbd56744fb6e2e9cd8e"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6417,7 +6836,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.9",
  "http-body 0.4.5",
  "hyper 0.14.27",
  "hyper-rustls",
@@ -7490,7 +7909,7 @@ name = "starknet-crypto"
 version = "0.6.1"
 source = "git+https://github.com/fracek/starknet-rs?rev=e6c4a21a7ce5#e6c4a21a7ce53c5fb3faa2f8dc9d71dd5afe4342"
 dependencies = [
- "crypto-bigint 0.5.3",
+ "crypto-bigint 0.5.5",
  "hex",
  "hmac",
  "num-bigint",
@@ -7529,7 +7948,7 @@ source = "git+https://github.com/fracek/starknet-rs?rev=e6c4a21a7ce5#e6c4a21a7ce
 dependencies = [
  "ark-ff",
  "bigdecimal",
- "crypto-bigint 0.5.3",
+ "crypto-bigint 0.5.5",
  "getrandom 0.2.10",
  "hex",
  "num-bigint",
@@ -7571,7 +7990,7 @@ source = "git+https://github.com/fracek/starknet-rs?rev=e6c4a21a7ce5#e6c4a21a7ce
 dependencies = [
  "async-trait",
  "auto_impl",
- "crypto-bigint 0.5.3",
+ "crypto-bigint 0.5.5",
  "eth-keystore",
  "rand 0.8.5",
  "starknet-core",
@@ -8668,7 +9087,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.9",
  "http-body 0.4.5",
  "hyper 0.14.27",
  "hyper-timeout",
@@ -8700,7 +9119,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.9",
  "http-body 0.4.5",
  "hyper 0.14.27",
  "hyper-timeout",
@@ -8801,7 +9220,7 @@ dependencies = [
  "bytes 1.5.0",
  "futures-core",
  "futures-util",
- "http",
+ "http 0.2.9",
  "http-body 0.4.5",
  "http-range-header",
  "mime",
@@ -9063,7 +9482,7 @@ dependencies = [
  "byteorder",
  "bytes 1.5.0",
  "data-encoding",
- "http",
+ "http 0.2.9",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -9082,7 +9501,7 @@ dependencies = [
  "byteorder",
  "bytes 1.5.0",
  "data-encoding",
- "http",
+ "http 0.2.9",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -9279,6 +9698,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "urlpattern"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9421,7 +9846,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "headers",
- "http",
+ "http 0.2.9",
  "hyper 0.14.27",
  "log",
  "mime",
@@ -9867,6 +10292,12 @@ checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,12 +1014,11 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "aws-config"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91bb1df3e5f0e47475498570cdd10ab0370bc1d7af3151aa0161d5f5876b6908"
+checksum = "8b30c39ebe61f75d1b3785362b1586b41991873c9ab3e317a9181c246fb71d82"
 dependencies = [
  "aws-credential-types",
- "aws-http",
  "aws-runtime",
  "aws-sdk-sso",
  "aws-sdk-ssooidc",
@@ -1045,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d67c6836a1009b23e3f4cd1457c83e0aa49a490d9c3033b53c3f7b8cf2facc0f"
+checksum = "33cc49dcdd31c8b6e79850a179af4c367669150c7ac0135f176c61bec81a70f7"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -1056,29 +1055,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-http"
-version = "0.60.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a081f0c4576f7549dd255987d2d23920eccaa90cdd21d6440f91e0d7537f0e0d"
-dependencies = [
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes 1.5.0",
- "http 0.2.9",
- "http-body 0.4.5",
- "pin-project-lite",
- "tracing",
-]
-
-[[package]]
 name = "aws-runtime"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab7bf4b9b083e6dc86e2bb4fb09a4daca97e12cc0bc174a6f51fe624c23aa87f"
+checksum = "eb031bff99877c26c28895766f7bb8484a05e24547e370768d6cc9db514662aa"
 dependencies = [
  "aws-credential-types",
- "aws-http",
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
@@ -1086,21 +1068,23 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
+ "bytes 1.5.0",
  "fastrand 2.0.1",
  "http 0.2.9",
+ "http-body 0.4.5",
  "percent-encoding",
+ "pin-project-lite",
  "tracing",
  "uuid 1.5.0",
 ]
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f94d9842a304e066d1eddea61c703fb217ce5a1063cc087d07c8de1db4535f7"
+checksum = "951f7730f51a2155c711c85c79f337fbc02a577fa99d2a0a8059acfce5392113"
 dependencies = [
  "aws-credential-types",
- "aws-http",
  "aws-runtime",
  "aws-sigv4",
  "aws-smithy-async",
@@ -1125,12 +1109,11 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865b1b85249196e4868a48a4b6683d60e19b82371b869297bc9982bc9f47de4b"
+checksum = "f486420a66caad72635bc2ce0ff6581646e0d32df02aa39dc983bfe794955a5b"
 dependencies = [
  "aws-credential-types",
- "aws-http",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
@@ -1148,12 +1131,11 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beadaf5c48f5d923329ec87b7db6eea5e4ce2af4cc9f96d9f85d520f34573f40"
+checksum = "39ddccf01d82fce9b4a15c8ae8608211ee7db8ed13a70b514bbfe41df3d24841"
 dependencies = [
  "aws-credential-types",
- "aws-http",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
@@ -1171,12 +1153,11 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262a6d40c8e11eea633ba541a39745cebfcee9c1683020cee63413048b5c6188"
+checksum = "1a591f8c7e6a621a501b2b5d2e88e1697fcb6274264523a6ad4d5959889a41ce"
 dependencies = [
  "aws-credential-types",
- "aws-http",
  "aws-runtime",
  "aws-smithy-async",
  "aws-smithy-http",
@@ -1195,9 +1176,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511879249616f30e30fd2fa81edb4833784f65dd5d56053b7de2e2bcb583dda7"
+checksum = "c371c6b0ac54d4605eb6f016624fb5c7c2925d315fdf600ac1bf21b19d5f1742"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -1380,9 +1361,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2739d97d47f47cdf0d27982019a405dcc736df25925d1a75049f1faa79df88"
+checksum = "789bbe008e65636fe1b6dbbb374c40c8960d1232b96af5ff4aec349f9c4accf4"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ ctrlc = { version = "3.2.3", features = ["termination"] }
 dirs = "4.0.0"
 dotenvy = "0.15.7"
 error-stack = "0.4.1"
-flate2 = "1.0"
 futures = "0.3.23"
 futures-util = "0.3.26"
 governor = "0.6.0"

--- a/sinks/sink-parquet/Cargo.toml
+++ b/sinks/sink-parquet/Cargo.toml
@@ -35,6 +35,8 @@ serde_json.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
+aws-sdk-s3 = "1.13.0"
+aws-config = "1.1.3"
 
 [target.'cfg(not(windows))'.dependencies]
 jemallocator.workspace = true

--- a/sinks/sink-parquet/Cargo.toml
+++ b/sinks/sink-parquet/Cargo.toml
@@ -15,6 +15,8 @@ name = "apibara-sink-parquet"
 path = "src/bin.rs"
 
 [dependencies]
+aws-sdk-s3 = "1.13.0"
+aws-config = "1.1.3"
 apibara-core = { path = "../../core" }
 apibara-observability = { path = "../../observability" }
 apibara-sink-common = { path = "../sink-common" }
@@ -35,8 +37,6 @@ serde_json.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
-aws-sdk-s3 = "1.13.0"
-aws-config = "1.1.3"
 
 [target.'cfg(not(windows))'.dependencies]
 jemallocator.workspace = true

--- a/sinks/sink-parquet/src/configuration.rs
+++ b/sinks/sink-parquet/src/configuration.rs
@@ -17,6 +17,10 @@ pub struct SinkParquetConfiguration {
 #[sink_options(tag = "parquet")]
 pub struct SinkParquetOptions {
     /// The output directory to write the parquet files to.
+    ///
+    /// If it starts with `s3://`, the files will be written to S3. The S3 credentials are loaded using the default AWS credentials provider chain.
+    ///
+    /// Otherwise, they will be written to the local filesystem. If the directory does not exist, it will be created.
     #[arg(long, env = "PARQUET_OUTPUT_DIR")]
     pub output_dir: Option<String>,
     /// The batch size to use when writing parquet files.

--- a/sinks/sink-parquet/src/lib.rs
+++ b/sinks/sink-parquet/src/lib.rs
@@ -1,4 +1,5 @@
 mod configuration;
+mod parquet_writer;
 mod sink;
 
 pub use self::configuration::{SinkParquetConfiguration, SinkParquetOptions};

--- a/sinks/sink-parquet/src/parquet_writer.rs
+++ b/sinks/sink-parquet/src/parquet_writer.rs
@@ -1,0 +1,116 @@
+use std::{
+    fs::{self, File},
+    io::Write,
+    path::PathBuf,
+};
+
+use async_trait::async_trait;
+use aws_sdk_s3::{primitives::ByteStream, Client};
+use error_stack::{Result, ResultExt};
+
+use crate::SinkParquetError;
+
+#[async_trait]
+pub trait ParquetWriter {
+    async fn write_parquet(&mut self, path: PathBuf, data: &[u8]) -> Result<(), SinkParquetError>;
+}
+
+pub struct FileParquetWriter;
+
+#[async_trait]
+impl ParquetWriter for FileParquetWriter {
+    async fn write_parquet(&mut self, path: PathBuf, data: &[u8]) -> Result<(), SinkParquetError> {
+        let path = if path.starts_with("file://") {
+            // Safe to unwrap because we know the path starts with "file://"
+            path.strip_prefix("file://").unwrap()
+        } else {
+            &path
+        };
+
+        let output_dir = path
+            .parent()
+            .ok_or(SinkParquetError)
+            .attach_printable(format!("cannot get parent directory of `{path:?}`"))?;
+
+        fs::create_dir_all(output_dir)
+            .change_context(SinkParquetError)
+            .attach_printable(format!(
+                "failed to create output directory `{output_dir:?}`"
+            ))?;
+
+        let mut file = File::create(path)
+            .change_context(SinkParquetError)
+            .attach_printable(format!("failed to create parquet file at `{path:?}`"))?;
+
+        file.write_all(data)
+            .change_context(SinkParquetError)
+            .attach_printable(format!("failed to write parquet to file at `{path:?}`"))?;
+
+        Ok(())
+    }
+}
+
+pub struct S3ParquetWriter {
+    client: Client,
+}
+
+#[async_trait]
+impl ParquetWriter for S3ParquetWriter {
+    async fn write_parquet(&mut self, path: PathBuf, data: &[u8]) -> Result<(), SinkParquetError> {
+        let path = path
+            .as_os_str()
+            .to_str()
+            .ok_or(SinkParquetError)
+            .attach_printable(format!("cannot convert path `{path:?}` to string"))?;
+
+        let mut path_parts = path
+            .strip_prefix("s3://")
+            .ok_or(SinkParquetError)
+            .attach_printable(format!("provided path is not an s3 URL `{path:?}`"))?
+            .split('/');
+
+        let bucket_name = path_parts
+            .next()
+            .ok_or(SinkParquetError)
+            .attach_printable(format!("cannot get the bucket name from `{path:?}`"))?;
+
+        let key = path_parts.collect::<Vec<&str>>().join("/");
+        let body = ByteStream::from(data.to_vec());
+
+        let result = self
+            .client
+            .put_object()
+            .bucket(bucket_name)
+            .key(key)
+            .body(body)
+            .send()
+            .await;
+
+        match result {
+            Ok(_) => Ok(()),
+            Err(err) => Err(SinkParquetError)
+                .attach_printable(format!("failed to write parquet to s3 at `{path:?}`"))
+                // For some reason, we need to attach the error to the report,
+                // otherwise the error is not printed.
+                .attach_printable(format!("error: {err:?}")),
+        }
+    }
+}
+
+/// Write a parquet file to the given path.
+///
+/// If the path starts with `"s3://"`, the file will be written to S3, the S3 credentials will be loaded using the default AWS credentials provider chain.
+///
+/// Otherwise, the file will be written to the local filesystem.
+/// If the file already exists, it will be overwritten. If the parent directory does not exist, it will be created.
+pub async fn write_parquet(path: PathBuf, data: &[u8]) -> Result<(), SinkParquetError> {
+    if path.starts_with("s3://") {
+        let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+        let client = Client::new(&config);
+        let mut writer = S3ParquetWriter { client };
+        writer.write_parquet(path, data).await
+    } else {
+        let mut writer = FileParquetWriter;
+        writer.write_parquet(path, data).await
+    }
+}

--- a/sinks/sink-parquet/src/parquet_writer.rs
+++ b/sinks/sink-parquet/src/parquet_writer.rs
@@ -71,7 +71,13 @@ impl ParquetWriter for S3ParquetWriter {
 
         let bucket_name = path_parts
             .next()
-            .and_then(|bucket_name| if bucket_name.is_empty() { None } else { Some(bucket_name) })
+            .and_then(|bucket_name| {
+                if bucket_name.is_empty() {
+                    None
+                } else {
+                    Some(bucket_name)
+                }
+            })
             .ok_or(SinkParquetError)
             .attach_printable(format!("cannot get the bucket name from `{path:?}`"))?;
 

--- a/sinks/sink-parquet/src/sink.rs
+++ b/sinks/sink-parquet/src/sink.rs
@@ -1,9 +1,7 @@
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::fmt;
-use std::io::Write;
 
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use apibara_core::node::v1alpha2::Cursor;

--- a/sinks/sink-parquet/tests/test_sink.rs
+++ b/sinks/sink-parquet/tests/test_sink.rs
@@ -21,7 +21,7 @@ fn read_parquet(output_dir: &TempDir, file_name: &str) -> RecordBatch {
     reader.next().unwrap().unwrap()
 }
 
-fn new_sink(batch_size: usize) -> (TempDir, ParquetSink) {
+async fn new_sink(batch_size: usize) -> (TempDir, ParquetSink) {
     let output_dir = TempDir::new("sink_parquet_test").unwrap();
 
     let config = SinkParquetConfiguration {
@@ -30,7 +30,7 @@ fn new_sink(batch_size: usize) -> (TempDir, ParquetSink) {
         batch_size,
     };
 
-    (output_dir, ParquetSink::new(config))
+    (output_dir, ParquetSink::new(config).await)
 }
 
 fn new_batch(start_cursor: &Option<Cursor>, end_cursor: &Cursor) -> Value {
@@ -102,7 +102,7 @@ fn get_file_names(output_dir: &TempDir, path: &str) -> Option<Vec<OsString>> {
 #[ignore]
 async fn test_handle_data() -> Result<(), SinkParquetError> {
     let parquet_batch_size = 10;
-    let (output_dir, mut sink) = new_sink(parquet_batch_size);
+    let (output_dir, mut sink) = new_sink(parquet_batch_size).await;
 
     let finality = DataFinality::DataStatusFinalized;
 

--- a/starknet/tests/test_node.rs
+++ b/starknet/tests/test_node.rs
@@ -26,7 +26,7 @@ async fn test_starknet_reorgs() {
     init_opentelemetry().unwrap();
 
     let docker = clients::Cli::default();
-    let devnet = docker.run(Devnet::default());
+    let devnet = docker.run(Devnet);
 
     let rpc_port = devnet.get_host_port_ipv4(5050);
     let devnet_client = DevnetClient::new(format!("http://localhost:{}", rpc_port));

--- a/starknet/tests/test_reorgs.rs
+++ b/starknet/tests/test_reorgs.rs
@@ -25,7 +25,7 @@ async fn test_reorg_from_client_pov() {
     init_opentelemetry().unwrap();
 
     let docker = clients::Cli::default();
-    let devnet = docker.run(Devnet::default());
+    let devnet = docker.run(Devnet);
 
     let rpc_port = devnet.get_host_port_ipv4(5050);
     let cts = CancellationToken::new();

--- a/starknet/tests/test_websockets.rs
+++ b/starknet/tests/test_websockets.rs
@@ -28,7 +28,7 @@ async fn test_reorg_from_client_pov_websockets() {
     init_opentelemetry().unwrap();
 
     let docker = clients::Cli::default();
-    let devnet = docker.run(Devnet::default());
+    let devnet = docker.run(Devnet);
 
     let rpc_port = devnet.get_host_port_ipv4(5050);
     let cts = CancellationToken::new();


### PR DESCRIPTION
Simply by setting the `--output-dir` to an S3 URL like `s3://bucket/`,
the S3 credentials will be loaded using the default AWS credentials provider chain