### PR TITLE
starknet: increase database size to 512Gb

### DIFF
--- a/starknet/src/node.rs
+++ b/starknet/src/node.rs
@@ -315,7 +315,7 @@ where
         fs::create_dir_all(&self.datadir).map_err(StarkNetNodeBuilderError::CreateDatadir)?;
 
         let db = Environment::<E>::builder()
-            .with_size_gib(10, 256)
+            .with_size_gib(10, 512)
             .with_growth_step_gib(2)
             .open(&self.datadir)
             .map_err(StarkNetNodeBuilderError::DatabaseOpen)?;


### PR DESCRIPTION
**Summary**
The mainnet database is getting closer to 256Gb, so it's time to bump
the maximum size again.