### PR TITLE
sink: add filesystem read/write permissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-console"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-postgres"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "apibara-core",
  "apibara-observability",

--- a/cli/src/run.rs
+++ b/cli/src/run.rs
@@ -62,6 +62,14 @@ pub async fn run(args: RunArgs) -> Result<(), CliError> {
         extra_args.push("--allow-net".to_string());
         extra_args.push(allow_net.join(",").to_string());
     };
+    if let Some(allow_read) = args.transform.allow_read {
+        extra_args.push("--allow-read".to_string());
+        extra_args.push(allow_read.join(",").to_string());
+    };
+    if let Some(allow_write) = args.transform.allow_write {
+        extra_args.push("--allow-write".to_string());
+        extra_args.push(allow_write.join(",").to_string());
+    };
     if let Some(transform_timeout) = args.transform.script_transform_timeout_seconds {
         extra_args.push("--script-transform-timeout-seconds".to_string());
         extra_args.push(transform_timeout.to_string());

--- a/sinks/sink-common/src/configuration.rs
+++ b/sinks/sink-common/src/configuration.rs
@@ -85,6 +85,16 @@ pub struct ScriptOptions {
     /// Leave empty to allow all hosts, i.e. by specifying `--allow-net`.
     #[arg(long, env, value_delimiter = ',', num_args = 0..)]
     pub allow_net: Option<Vec<String>>,
+    /// Grant file system write access to the paths.
+    ///
+    /// Leave empty to allow all paths, i.e. by specifying `--allow-write`.
+    #[arg(long, env, value_delimiter = ',', num_args = 0..)]
+    pub allow_write: Option<Vec<String>>,
+    /// Grant file system read access to the paths.
+    ///
+    /// Leave empty to allow all paths, i.e. by specifying `--allow-write`.
+    #[arg(long, env, value_delimiter = ',', num_args = 0..)]
+    pub allow_read: Option<Vec<String>>,
     /// Maximum time allowed to execute the transform function.
     #[arg(long, env)]
     pub script_transform_timeout_seconds: Option<u64>,
@@ -365,6 +375,8 @@ impl ScriptOptions {
         IndexerOptions {
             allow_env: self.allow_env_from_env,
             allow_net: self.allow_net,
+            allow_read: self.allow_read,
+            allow_write: self.allow_write,
             transform_timeout: self
                 .script_transform_timeout_seconds
                 .map(Duration::from_secs),

--- a/sinks/sink-console/CHANGELOG.md
+++ b/sinks/sink-console/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.4] - 2024-01-27
+
+_Read and write data from the filesystem._
+
+### Added
+
+-   Add the `--allow-read` and `--allow-write` flags to grant read and write access to the filesystem. You can leave the arguments empty to allow access to any path, or restrict access to specific paths by specifying a comma-separated list of paths.
+
 ## [0.4.3] - 2024-01-25
 
 _Persist state to Redis._
@@ -187,6 +195,7 @@ _This release improves the developer experience when running locally._
 
 _First tagged release 🎉_
 
+[0.4.4]: https://github.com/apibara/dna/releases/tag/sink-console/v0.4.4
 [0.4.3]: https://github.com/apibara/dna/releases/tag/sink-console/v0.4.3
 [0.4.2]: https://github.com/apibara/dna/releases/tag/sink-console/v0.4.2
 [0.4.1]: https://github.com/apibara/dna/releases/tag/sink-console/v0.4.1

--- a/sinks/sink-console/Cargo.toml
+++ b/sinks/sink-console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-console"
-version = "0.4.3"
+version = "0.4.4"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-postgres/CHANGELOG.md
+++ b/sinks/sink-postgres/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.5] - 2024-01-27
+
+_Read and write data from the filesystem._
+
+### Added
+
+-   Add the `--allow-read` and `--allow-write` flags to grant read and write access to the filesystem. You can leave the arguments empty to allow access to any path, or restrict access to specific paths by specifying a comma-separated list of paths.
+
 ## [0.5.4] - 2024-01-25
 
 _Persist state to Redis._
@@ -236,6 +244,7 @@ _This release improves the developer experience when running locally._
 
 _First tagged release 🎉_
 
+[0.5.5]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.5.5
 [0.5.4]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.5.4
 [0.5.3]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.5.3
 [0.5.2]: https://github.com/apibara/dna/releases/tag/sink-postgres/v0.5.2

--- a/sinks/sink-postgres/Cargo.toml
+++ b/sinks/sink-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-postgres"
-version = "0.5.4"
+version = "0.5.5"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
sink: add filesystem read/write permissions

**Summary**
Allow indexers to read and write data from the filesystem.
Filesystem access is granted with the `--allow-read` and `--allow-write`
flags.

release: sink-{console, postgres}

**Summary**
sink-console: v0.4.4
sink-postgres: v0.5.5