### PR TITLE
mongo: add --batch-secs flag to configure the rate of database writes

### DIFF
--- a/sinks/sink-common/src/connector/batching.rs
+++ b/sinks/sink-common/src/connector/batching.rs
@@ -1,0 +1,188 @@
+use std::time::Instant;
+
+use apibara_core::node::v1alpha2::{Cursor, DataFinality};
+use error_stack::Result;
+use serde_json::Value;
+use tracing::{info, warn};
+
+use crate::{error::SinkError, sink::Context, CursorAction, ValueExt};
+
+pub struct Buffer {
+    pub start_at: Instant,
+    pub start_cursor: Cursor,
+    pub end_cursor: Cursor,
+    pub data: Vec<Value>,
+}
+
+impl Default for Buffer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Buffer {
+    pub fn new() -> Self {
+        Self {
+            start_at: Instant::now(),
+            start_cursor: Cursor::default(),
+            end_cursor: Cursor::default(),
+            data: Vec::new(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    pub fn to_vec(&self) -> Vec<Value> {
+        self.data.to_vec()
+    }
+
+    pub fn extend(&mut self, data: Vec<Value>) {
+        self.data.extend(data);
+    }
+
+    pub fn clear(&mut self) {
+        self.start_at = Instant::now();
+        self.start_cursor = Cursor::default();
+        self.end_cursor = Cursor::default();
+        self.data.clear();
+    }
+}
+
+pub struct Batcher {
+    pub batch_size: u64,
+    pub batch_secs: u64,
+    pub buffer: Buffer,
+}
+
+impl Batcher {
+    pub fn by_secs(batch_secs: u64) -> Self {
+        Self {
+            batch_size: 0,
+            batch_secs,
+            buffer: Buffer::new(),
+        }
+    }
+
+    pub fn by_size(batch_size: u64) -> Self {
+        Self {
+            batch_size,
+            batch_secs: 0,
+            buffer: Buffer::new(),
+        }
+    }
+
+    pub fn is_batching_by_secs(&self) -> bool {
+        self.batch_secs != 0
+    }
+
+    pub fn is_batching_by_size(&self) -> bool {
+        self.batch_size != 0
+    }
+
+    pub fn is_batching(&self) -> bool {
+        self.is_batching_by_secs() || self.is_batching_by_size()
+    }
+
+    pub fn should_flush(&self) -> bool {
+        let batch_by_size_reached = (self.buffer.end_cursor.order_key
+            - self.buffer.start_cursor.order_key)
+            >= self.batch_size;
+
+        let batch_by_secs_reached = self.buffer.start_at.elapsed().as_secs() >= self.batch_secs;
+
+        (self.is_batching_by_size() && batch_by_size_reached)
+            || (self.is_batching_by_secs() && batch_by_secs_reached)
+    }
+
+    pub fn flush(&mut self) -> (Cursor, Vec<Value>) {
+        let batch = self.buffer.to_vec();
+        let end_cursor = self.buffer.end_cursor.clone();
+
+        self.buffer.clear();
+
+        (end_cursor, batch)
+    }
+
+    pub fn clear(&mut self) {
+        self.buffer.clear()
+    }
+
+    pub fn is_flushed(&self) -> bool {
+        self.buffer.is_empty()
+    }
+
+    pub async fn add_data(&mut self, ctx: &Context, batch: &Value) {
+        // TODO: do something about it ? Why do we have to do this here again ?
+        // we already do this in the `handle_data` function
+        let batch = batch
+            .as_array_of_objects()
+            .unwrap_or(&Vec::<Value>::new())
+            .to_vec();
+
+        if self.buffer.start_cursor == Cursor::default() {
+            self.buffer.start_cursor = ctx.cursor.clone().unwrap_or_default();
+        }
+        self.buffer.end_cursor = ctx.end_cursor.clone();
+        self.buffer.extend(batch);
+    }
+
+    pub async fn handle_data(
+        &mut self,
+        ctx: &Context,
+        batch: &Value,
+    ) -> Result<(CursorAction, Option<(Cursor, Vec<Value>)>), SinkError> {
+        let Some(batch) = batch.as_array_of_objects() else {
+            warn!("data is not an array of objects, skipping");
+            // Skip persistence in case the buffer is still not flushed
+            if self.is_batching() && !self.is_flushed() {
+                return Ok((CursorAction::Skip, None));
+            } else {
+                return Ok((CursorAction::Persist, None));
+            }
+        };
+
+        if batch.is_empty() {
+            warn!("data is empty, skipping");
+            // Skip persistence if the buffer is still not flushed
+            if self.is_batching() && !self.is_flushed() {
+                return Ok((CursorAction::Skip, None));
+            } else {
+                return Ok((CursorAction::Persist, None));
+            }
+        }
+
+        if !self.is_batching() || (ctx.finality != DataFinality::DataStatusFinalized) {
+            return Ok((
+                CursorAction::Persist,
+                Some((ctx.end_cursor.clone(), batch.to_vec())),
+            ));
+        }
+
+        if self.should_flush() {
+            info!(
+                "handling batch of {} elements after {} seconds: {:?}",
+                self.buffer.len(),
+                self.buffer.start_at.elapsed().as_secs(),
+                self.buffer.data,
+            );
+
+            return Ok((
+                // Persist the cursor of the end of the buffer, since the current
+                // batch is not added the buffer
+                // This is to make the function idempotent because it'll be called
+                // multiple times with the same data by [`SinkWithBackoff`]
+                // if the sink fails
+                CursorAction::PersistAt(self.buffer.end_cursor.clone()),
+                Some((self.buffer.end_cursor.clone(), self.buffer.to_vec())),
+            ));
+        }
+
+        Ok((CursorAction::Skip, None))
+    }
+}

--- a/sinks/sink-common/src/connector/mod.rs
+++ b/sinks/sink-common/src/connector/mod.rs
@@ -1,3 +1,4 @@
+pub mod batching;
 mod default;
 mod factory;
 mod sink;

--- a/sinks/sink-common/src/connector/sink.rs
+++ b/sinks/sink-common/src/connector/sink.rs
@@ -3,7 +3,7 @@ use error_stack::{Result, ResultExt};
 use exponential_backoff::Backoff;
 use serde_json::Value;
 use tokio_util::sync::CancellationToken;
-use tracing::{warn};
+use tracing::warn;
 
 use crate::{
     error::SinkError,

--- a/sinks/sink-common/src/connector/state.rs
+++ b/sinks/sink-common/src/connector/state.rs
@@ -57,11 +57,15 @@ impl StateManager {
             .update_cursor(state.cursor.clone())
             .await?;
 
-        if action == CursorAction::Persist {
-            self.persistence.put_state(state).await?;
+        match action {
+            CursorAction::PersistAt(cursor) => {
+                self.persistence
+                    .put_state(PersistedState::new(Some(cursor), state.filter))
+                    .await
+            }
+            CursorAction::Persist => self.persistence.put_state(state).await,
+            CursorAction::Skip => Ok(()),
         }
-
-        Ok(())
     }
 
     pub async fn heartbeat(&mut self) -> Result<(), SinkError> {

--- a/sinks/sink-common/src/sink.rs
+++ b/sinks/sink-common/src/sink.rs
@@ -15,6 +15,7 @@ pub trait SinkOptions: DeserializeOwned {
 #[derive(Debug, PartialEq)]
 pub enum CursorAction {
     Persist,
+    PersistAt(Cursor),
     Skip,
 }
 

--- a/sinks/sink-mongo/src/configuration.rs
+++ b/sinks/sink-mongo/src/configuration.rs
@@ -25,6 +25,10 @@ pub struct SinkMongoOptions {
     pub entity_mode: Option<bool>,
     #[clap(skip)]
     pub invalidate: Option<Document>,
+    /// The batch time in seconds.
+    /// If set, the sink will batch the data and send it to the database every `batch_secs` seconds.
+    #[arg(long, env = "MONGO_BATCH_SECS")]
+    pub batch_secs: Option<u64>,
 }
 
 impl SinkOptions for SinkMongoOptions {
@@ -36,6 +40,7 @@ impl SinkOptions for SinkMongoOptions {
             collection_names: self.collection_names.or(other.collection_names),
             entity_mode: self.entity_mode.or(other.entity_mode),
             invalidate: self.invalidate.or(other.invalidate),
+            batch_secs: self.batch_secs.or(other.batch_secs),
         }
     }
 }

--- a/sinks/sink-mongo/src/configuration.rs
+++ b/sinks/sink-mongo/src/configuration.rs
@@ -25,8 +25,8 @@ pub struct SinkMongoOptions {
     pub entity_mode: Option<bool>,
     #[clap(skip)]
     pub invalidate: Option<Document>,
-    #[arg(long, env = "MONGO_BATCH_SECS")]
-    pub batch_secs: Option<u64>,
+    #[arg(long, env = "MONGO_BATCH_SECONDS")]
+    pub batch_seconds: Option<u64>,
 }
 
 impl SinkOptions for SinkMongoOptions {
@@ -38,7 +38,7 @@ impl SinkOptions for SinkMongoOptions {
             collection_names: self.collection_names.or(other.collection_names),
             entity_mode: self.entity_mode.or(other.entity_mode),
             invalidate: self.invalidate.or(other.invalidate),
-            batch_secs: self.batch_secs.or(other.batch_secs),
+            batch_seconds: self.batch_seconds.or(other.batch_seconds),
         }
     }
 }

--- a/sinks/sink-mongo/src/configuration.rs
+++ b/sinks/sink-mongo/src/configuration.rs
@@ -25,8 +25,6 @@ pub struct SinkMongoOptions {
     pub entity_mode: Option<bool>,
     #[clap(skip)]
     pub invalidate: Option<Document>,
-    /// The batch time in seconds.
-    /// If set, the sink will batch the data and send it to the database every `batch_secs` seconds.
     #[arg(long, env = "MONGO_BATCH_SECS")]
     pub batch_secs: Option<u64>,
 }

--- a/sinks/sink-mongo/src/lib.rs
+++ b/sinks/sink-mongo/src/lib.rs
@@ -2,4 +2,4 @@ mod configuration;
 mod sink;
 
 pub use self::configuration::SinkMongoOptions;
-pub use self::sink::{MongoSink, SinkMongoError};
+pub use self::sink::{Batch, MongoSink, SinkMongoError};

--- a/sinks/sink-mongo/src/sink.rs
+++ b/sinks/sink-mongo/src/sink.rs
@@ -119,7 +119,7 @@ impl Sink for MongoSink {
             client,
             mode,
             invalidate: options.invalidate,
-            batcher: Batcher::by_secs(options.batch_secs.unwrap_or_default()),
+            batcher: Batcher::by_seconds(options.batch_seconds.unwrap_or_default()),
         })
     }
 

--- a/sinks/sink-mongo/tests/test_multi_collection.rs
+++ b/sinks/sink-mongo/tests/test_multi_collection.rs
@@ -389,7 +389,7 @@ async fn test_handle_data_in_entity_mode() -> Result<(), SinkMongoError> {
         collection_names: Some(collection_names.clone()),
         entity_mode: Some(true),
         invalidate: None,
-        batch_secs: None,
+        batch_seconds: None,
     };
 
     let mut sink = MongoSink::from_options(options).await?;
@@ -545,7 +545,7 @@ async fn test_handle_invalidate_in_entity_mode() -> Result<(), SinkMongoError> {
         collection_names: Some(collection_names.clone()),
         entity_mode: Some(true),
         invalidate: None,
-        batch_secs: None,
+        batch_seconds: None,
     };
 
     let mut sink = MongoSink::from_options(options).await?;

--- a/sinks/sink-mongo/tests/test_multi_collection.rs
+++ b/sinks/sink-mongo/tests/test_multi_collection.rs
@@ -389,6 +389,7 @@ async fn test_handle_data_in_entity_mode() -> Result<(), SinkMongoError> {
         collection_names: Some(collection_names.clone()),
         entity_mode: Some(true),
         invalidate: None,
+        batch_secs: None,
     };
 
     let mut sink = MongoSink::from_options(options).await?;
@@ -544,6 +545,7 @@ async fn test_handle_invalidate_in_entity_mode() -> Result<(), SinkMongoError> {
         collection_names: Some(collection_names.clone()),
         entity_mode: Some(true),
         invalidate: None,
+        batch_secs: None,
     };
 
     let mut sink = MongoSink::from_options(options).await?;

--- a/sinks/sink-mongo/tests/test_sink.rs
+++ b/sinks/sink-mongo/tests/test_sink.rs
@@ -303,6 +303,7 @@ async fn test_handle_data_in_entity_mode() -> Result<(), SinkMongoError> {
         collection_names: None,
         entity_mode: Some(true),
         invalidate: None,
+        batch_secs: None,
     };
 
     let mut sink = MongoSink::from_options(options).await?;
@@ -452,6 +453,7 @@ async fn test_handle_invalidate_in_entity_mode() -> Result<(), SinkMongoError> {
         collection_names: None,
         entity_mode: Some(true),
         invalidate: None,
+        batch_secs: None,
     };
 
     let mut sink = MongoSink::from_options(options).await?;

--- a/sinks/sink-mongo/tests/test_sink.rs
+++ b/sinks/sink-mongo/tests/test_sink.rs
@@ -565,7 +565,7 @@ async fn test_handle_invalidate_in_entity_mode() -> Result<(), SinkMongoError> {
 }
 
 #[tokio::test]
-// #[ignore]
+#[ignore]
 async fn test_handle_data_batch_mode() -> Result<(), SinkMongoError> {
     let docker = clients::Cli::default();
     let mongo = docker.run(new_mongo_image());
@@ -672,7 +672,7 @@ async fn test_handle_data_batch_mode() -> Result<(), SinkMongoError> {
 }
 
 #[tokio::test]
-// #[ignore]
+#[ignore]
 async fn test_invalidate_batch_mode() -> Result<(), SinkMongoError> {
     let docker = clients::Cli::default();
     let mongo = docker.run(new_mongo_image());

--- a/sinks/sink-mongo/tests/test_sink.rs
+++ b/sinks/sink-mongo/tests/test_sink.rs
@@ -308,7 +308,7 @@ async fn test_handle_data_in_entity_mode() -> Result<(), SinkMongoError> {
         collection_names: None,
         entity_mode: Some(true),
         invalidate: None,
-        batch_secs: None,
+        batch_seconds: None,
     };
 
     let mut sink = MongoSink::from_options(options).await?;
@@ -458,7 +458,7 @@ async fn test_handle_invalidate_in_entity_mode() -> Result<(), SinkMongoError> {
         collection_names: None,
         entity_mode: Some(true),
         invalidate: None,
-        batch_secs: None,
+        batch_seconds: None,
     };
 
     let mut sink = MongoSink::from_options(options).await?;
@@ -571,14 +571,14 @@ async fn test_handle_data_batch_mode() -> Result<(), SinkMongoError> {
     let mongo = docker.run(new_mongo_image());
     let port = mongo.get_host_port_ipv4(27017);
 
-    let batch_secs = 1;
+    let batch_seconds = 1;
 
     let options = SinkMongoOptions {
         connection_string: Some(format!("mongodb://localhost:{}", port)),
         database: Some("test".into()),
         collection_name: Some("test".into()),
         collection_names: None,
-        batch_secs: Some(batch_secs),
+        batch_seconds: Some(batch_seconds),
         ..SinkMongoOptions::default()
     };
 
@@ -625,7 +625,7 @@ async fn test_handle_data_batch_mode() -> Result<(), SinkMongoError> {
         buffer.end_cursor = end_cursor.clone();
 
         // Test batching
-        if buffer.start_at.elapsed().as_secs() < batch_secs {
+        if buffer.start_at.elapsed().as_secs() < batch_seconds {
             assert_eq!(buffer.data, sink.batcher.buffer.data);
             assert_eq!(buffer.end_cursor, sink.batcher.buffer.end_cursor);
             assert_eq!(action, CursorAction::Skip);
@@ -678,14 +678,14 @@ async fn test_invalidate_batch_mode() -> Result<(), SinkMongoError> {
     let mongo = docker.run(new_mongo_image());
     let port = mongo.get_host_port_ipv4(27017);
 
-    let batch_secs = 1;
+    let batch_seconds = 1;
 
     let options = SinkMongoOptions {
         connection_string: Some(format!("mongodb://localhost:{}", port)),
         database: Some("test".into()),
         collection_name: Some("test".into()),
         collection_names: None,
-        batch_secs: Some(batch_secs),
+        batch_seconds: Some(batch_seconds),
         ..SinkMongoOptions::default()
     };
 
@@ -714,7 +714,7 @@ async fn test_invalidate_batch_mode() -> Result<(), SinkMongoError> {
         get_all_docs(sink.collection("test")?).await,
     );
 
-    sleep(Duration::from_secs(batch_secs)).await;
+    sleep(Duration::from_secs(batch_seconds)).await;
 
     assert_eq!(
         Vec::<Document>::new(),

--- a/sinks/sink-parquet/src/sink.rs
+++ b/sinks/sink-parquet/src/sink.rs
@@ -152,6 +152,9 @@ impl Sink for ParquetSink {
         ctx: &Context,
         batch: &Value,
     ) -> Result<CursorAction, Self::Error> {
+        let len = batch.as_array_of_objects().unwrap().len();
+        info!(ctx = %ctx, batch = %len, "handling data");
+
         let Some(batch) = batch.as_array_of_objects() else {
             warn!("data is not an array of objects, skipping");
             // Skip persistence in case the buffer is still not flushed
@@ -160,10 +163,9 @@ impl Sink for ParquetSink {
 
         if batch.is_empty() {
             // Skip persistence in case the buffer is still not flushed
+            warn!("batch is empty, skipping");
             return Ok(CursorAction::Skip);
         }
-
-        debug!(ctx = %ctx, "handling data");
 
         let mut state = match self.state.take() {
             Some(state) => state,

--- a/sinks/sink-parquet/src/sink.rs
+++ b/sinks/sink-parquet/src/sink.rs
@@ -152,8 +152,6 @@ impl Sink for ParquetSink {
         ctx: &Context,
         batch: &Value,
     ) -> Result<CursorAction, Self::Error> {
-        let len = batch.as_array_of_objects().unwrap().len();
-        info!(ctx = %ctx, batch = %len, "handling data");
 
         let Some(batch) = batch.as_array_of_objects() else {
             warn!("data is not an array of objects, skipping");


### PR DESCRIPTION
mongo: add --batch-secs flag to configure the rate of database writes

mongo: add tests for batch mode

sink: WIP: refactoring batching logic

sink: polishing batching logic

sink: use the full name for seconds to avoid double guessing

sink: ignore integration test

sink-parquet: remove logging in handle_data

We already have logs for each batch in `sink-common`

Co-authored-by: Francesco Ceccon <francesco@ceccon.me>