### PR TITLE
release: sink-{mongo, parquet, postgres, webhook}

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-mongo"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-parquet"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-postgres"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-webhook"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "apibara-core",
  "apibara-observability",

--- a/sinks/sink-mongo/CHANGELOG.md
+++ b/sinks/sink-mongo/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2024-03-15
+
+_Batch insert documents._
+
+### Added
+
+-   Introduce the new `--batch-seconds` option to insert documents into the
+    collection at the specified interval. You should use this option if you find
+    the indexer is making too many small writes and wish to group them into
+    larger ones. This option only affects backfilling finalized data, recent
+    onchain data is inserted as soon as it's produced.
+
 ## [0.5.3] - 2024-01-25
 
 _Persist state to Redis._

--- a/sinks/sink-mongo/Cargo.toml
+++ b/sinks/sink-mongo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-mongo"
-version = "0.5.3"
+version = "0.6.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-parquet/CHANGELOG.md
+++ b/sinks/sink-parquet/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2024-03-15
+
+_Uploading data to Amazon S3 compatible storage._
+
+### Added
+
+-   You can now upload Parquet files directly to Amazon S3 compatible storage.
+    Change the `--output-dir` to an S3 URL like `s3://bucket/` to enable this mode.
+    The sink will authenticate with S3 using the default AWS environment variables
+    (e.g. `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`).
+
 ## [0.4.3] - 2024-01-25
 
 _Persist state to Redis._

--- a/sinks/sink-parquet/Cargo.toml
+++ b/sinks/sink-parquet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-parquet"
-version = "0.4.3"
+version = "0.5.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-postgres/CHANGELOG.md
+++ b/sinks/sink-postgres/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2024-03-15
+
+_Batch insert rows._
+
+### Added
+
+-   Introduce the new `--batch-seconds` option to insert rows into the
+    table at the specified interval. You should use this option if you find
+    the indexer is making too many small writes and wish to group them into
+    larger ones. This option only affects backfilling finalized data, recent
+    onchain data is inserted as soon as it's produced.
+
 ## [0.5.5] - 2024-01-27
 
 _Read and write data from the filesystem._

--- a/sinks/sink-postgres/Cargo.toml
+++ b/sinks/sink-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-postgres"
-version = "0.5.5"
+version = "0.6.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-webhook/CHANGELOG.md
+++ b/sinks/sink-webhook/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2024-03-15
+
+_Skip webhook invocation if data is `null`._
+
+### Changed
+
+-   The sink will not invoke the webhook if the data returned by the transform
+    function is `null`. Previously, this was the behavior of the sink in _raw_ mode,
+    now that's the behavior in normal mode too.
+
 ## [0.4.3] - 2024-01-25
 
 _Persist state to Redis._

--- a/sinks/sink-webhook/Cargo.toml
+++ b/sinks/sink-webhook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-webhook"
-version = "0.4.3"
+version = "0.5.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
- sink-mongo: v0.6.0
- sink-parquet: v0.5.0
- sink-postgres: v0.6.0
- sink-webhook: v0.5.0
