### PR TITLE
Downgrade nixpkgs to 23.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,15 +7,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1710003968,
-        "narHash": "sha256-g8+K+mLiNG5uch35Oy9oDQBAmGSkCcqrd0Jjme7xiG0=",
-        "owner": "ipetkov",
+        "lastModified": 1710671070,
+        "narHash": "sha256-XrSUtoeTAw/qiTqqotS1H3d5WANHvXAC+LV0TVIhX0Y=",
+        "owner": "fracek",
         "repo": "crane",
-        "rev": "10484f86201bb94bd61ecc5335b1496794fedb78",
+        "rev": "5be1e3c6643a9aad66d4f13da0d22416814bbb16",
         "type": "github"
       },
       "original": {
-        "owner": "ipetkov",
+        "owner": "fracek",
+        "ref": "5be1e3c664",
         "repo": "crane",
         "type": "github"
       }
@@ -58,16 +59,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1710283656,
-        "narHash": "sha256-nI+AOy4uK6jLGBi9nsbHjL1EdSIzoo8oa+9oeVhbyFc=",
+        "lastModified": 1704290814,
+        "narHash": "sha256-LWvKHp7kGxk/GEtlrGYV68qIvPHkU9iToomNFGagixU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "51063ed4f2343a59fdeebb279bb81d87d453942b",
+        "rev": "70bdadeb94ffc8806c0570eb5c2695ad29f0e421",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Apibara development environment";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
     flake-utils = {
       url = "github:numtide/flake-utils";
     };
@@ -11,7 +11,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     crane = {
-      url = "github:ipetkov/crane";
+      url = "github:fracek/crane/5be1e3c664";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };


### PR DESCRIPTION
**Summary**
NixOS 23.11 uses a version of GLIBC that's higher than the version
included in Ubuntu 22.04. This makes all packages compiled in the CI not
compatible with that version of Ubuntu.
This commit downgrades the nixpkgs version to use an older version of
GLIBC.
