### PR TITLE
release: sink-{mongo, parquet, postgres, webhook}

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-mongo"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-parquet"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-postgres"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-webhook"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "apibara-core",
  "apibara-observability",

--- a/sinks/sink-mongo/CHANGELOG.md
+++ b/sinks/sink-mongo/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2024-03-17
+
+_Fix compatibility with GLIBC < 2.38 (Ubuntu 22.04)._
+
+### Fixed
+
+-   Compile against GLIBC 2.34 to fix binaries not working on Linuxes
+    that use GLIBC 2.38 (e.g. Ubuntu 22.04).
+
 ## [0.6.0] - 2024-03-15
 
 _Batch insert documents._

--- a/sinks/sink-mongo/Cargo.toml
+++ b/sinks/sink-mongo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-mongo"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-parquet/CHANGELOG.md
+++ b/sinks/sink-parquet/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2024-03-17
+
+_Fix compatibility with GLIBC < 2.38 (Ubuntu 22.04)._
+
+### Fixed
+
+-   Compile against GLIBC 2.34 to fix binaries not working on Linuxes
+    that use GLIBC 2.38 (e.g. Ubuntu 22.04).
+
 ## [0.5.0] - 2024-03-15
 
 _Uploading data to Amazon S3 compatible storage._

--- a/sinks/sink-parquet/Cargo.toml
+++ b/sinks/sink-parquet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-parquet"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-postgres/CHANGELOG.md
+++ b/sinks/sink-postgres/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2024-03-17
+
+_Fix compatibility with GLIBC < 2.38 (Ubuntu 22.04)._
+
+### Fixed
+
+-   Compile against GLIBC 2.34 to fix binaries not working on Linuxes
+    that use GLIBC 2.38 (e.g. Ubuntu 22.04).
+
 ## [0.6.0] - 2024-03-15
 
 _Batch insert rows._

--- a/sinks/sink-postgres/Cargo.toml
+++ b/sinks/sink-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-postgres"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-webhook/CHANGELOG.md
+++ b/sinks/sink-webhook/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2024-03-17
+
+_Fix compatibility with GLIBC < 2.38 (Ubuntu 22.04)._
+
+### Fixed
+
+-   Compile against GLIBC 2.34 to fix binaries not working on Linuxes
+    that use GLIBC 2.38 (e.g. Ubuntu 22.04).
+
 ## [0.5.0] - 2024-03-15
 
 _Skip webhook invocation if data is `null`._

--- a/sinks/sink-webhook/Cargo.toml
+++ b/sinks/sink-webhook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-webhook"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
- sink-mongo: v0.6.1
- sink-parquet: v0.5.1
- sink-postgres: v0.6.1
- sink-webhook: v0.5.1
