### PR TITLE
Release sink-console 0.4.5

### DIFF
--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -164,6 +164,29 @@ jobs:
       - build-macos-aarch64-archive
     runs-on: ubuntu-latest
     steps:
-      - name: Publish binaries
+      - name: Download binary for Linux x86_64
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.target }}-x86_64-linux
+          path: /tmp/bin/x86_64-linux
+      - name: Download binary for Linux aarch64
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.target }}-aarch64-linux
+          path: /tmp/bin/aarch64-linux
+      - name: Download binary for MacOS aarch64
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.target }}-aarch64-macos
+          path: /tmp/bin/aarch64-macos
+      - name: Rename binaries
         run: |
-          echo "Publishing binaries ${{ inputs.target }}:${{ inputs.major }}.${{ inputs.minor }}.${{ inputs.patch }}"
+          mkdir /tmp/artifacts
+          cp /tmp/bin/x86_64-linux/${{ inputs.target }}.gz /tmp/artifacts/${{ inputs.target }}-x86_64-linux.gz
+          cp /tmp/bin/aarch64-linux/${{ inputs.target }}.gz /tmp/artifacts/${{ inputs.target }}-aarch64-linux.gz
+          cp /tmp/bin/aarch64-macos/${{ inputs.target }}.gz /tmp/artifacts/${{ inputs.target }}-aarch64-macos.gz
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file: /tmp/artifacts/*
+          file_glob: true

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -28,6 +28,7 @@ jobs:
   unit-test:
     name: Run unit tests
     runs-on: "${{ inputs.os }}"
+    needs: lint
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-console"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "apibara-core",
  "apibara-observability",

--- a/sinks/sink-console/CHANGELOG.md
+++ b/sinks/sink-console/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.5] - 2024-03-21
+
+_Update dependencies used to build the binary._
+
+### Changed
+
+-   This release simply updates the dependencies used to build the binary.
+    You should not expect any significant change.
+
 ## [0.4.4] - 2024-01-27
 
 _Read and write data from the filesystem._

--- a/sinks/sink-console/Cargo.toml
+++ b/sinks/sink-console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-console"
-version = "0.4.4"
+version = "0.4.5"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
### Summary

Release `sink-console` v0.4.5 to test the release process end to end.
