### PR TITLE
release: sink-{mongo, parquet, postgres, webhook}

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-mongo"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-parquet"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-postgres"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-webhook"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "apibara-core",
  "apibara-observability",

--- a/sinks/sink-mongo/CHANGELOG.md
+++ b/sinks/sink-mongo/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2024-03-21
+
+_Fix issue when transform does not return any data._
+
+### Fixed
+
+-   Fix a MongoDB error if the sink received no data from the transform
+    function. This usually happens once the indexer reaches the tip of the chain.
+
+### Added
+
+-   Support secure connections when connecting to Redis for persistence.
+    You can now use Redis connection strings that start with `rediss://`.
+
 ## [0.6.1] - 2024-03-17
 
 _Fix compatibility with GLIBC < 2.38 (Ubuntu 22.04)._

--- a/sinks/sink-mongo/Cargo.toml
+++ b/sinks/sink-mongo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-mongo"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-parquet/CHANGELOG.md
+++ b/sinks/sink-parquet/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2024-03-21
+
+_Add support for secure Redis persistence._
+
+### Added
+
+-   Support secure connections when connecting to Redis for persistence.
+    You can now use Redis connection strings that start with `rediss://`.
+
 ## [0.5.1] - 2024-03-17
 
 _Fix compatibility with GLIBC < 2.38 (Ubuntu 22.04)._

--- a/sinks/sink-parquet/Cargo.toml
+++ b/sinks/sink-parquet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-parquet"
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-postgres/CHANGELOG.md
+++ b/sinks/sink-postgres/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2024-03-21
+
+_Add support for secure Redis persistence._
+
+### Added
+
+-   Support secure connections when connecting to Redis for persistence.
+    You can now use Redis connection strings that start with `rediss://`.
+
 ## [0.6.1] - 2024-03-17
 
 _Fix compatibility with GLIBC < 2.38 (Ubuntu 22.04)._

--- a/sinks/sink-postgres/Cargo.toml
+++ b/sinks/sink-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-postgres"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-webhook/CHANGELOG.md
+++ b/sinks/sink-webhook/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2024-03-21
+
+_Add support for secure Redis persistence._
+
+### Added
+
+-   Support secure connections when connecting to Redis for persistence.
+    You can now use Redis connection strings that start with `rediss://`.
+
 ## [0.5.1] - 2024-03-17
 
 _Fix compatibility with GLIBC < 2.38 (Ubuntu 22.04)._

--- a/sinks/sink-webhook/Cargo.toml
+++ b/sinks/sink-webhook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-webhook"
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
### Summary

- sink-mongo: 0.6.2
- sink-parquet: 0.5.2
- sink-postgres: 0.6.2
- sink-webhook: 0.5.2

