### PR TITLE
Use transactions to replace pending data in MongoDB sink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-mongo"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "apibara-core",
  "apibara-observability",

--- a/examples/mongo/starknet_to_mongo.js
+++ b/examples/mongo/starknet_to_mongo.js
@@ -4,9 +4,10 @@ import { decodeTransfersInBlock, filter } from "../common/starknet.js";
 
 // Configure indexer for streaming Starknet Goerli data starting at the specified block.
 export const config = {
-  streamUrl: "https://goerli.starknet.a5a.ch",
-  startingBlock: 800_000,
+  streamUrl: "https://sepolia.starknet.a5a.ch",
+  startingBlock: 53_000,
   network: "starknet",
+  finality: "DATA_STATUS_PENDING",
   filter,
   sinkType: "mongo",
   sinkOptions: {

--- a/sinks/sink-common/src/sink.rs
+++ b/sinks/sink-common/src/sink.rs
@@ -41,6 +41,15 @@ pub trait Sink {
         batch: &Value,
     ) -> Result<CursorAction, Self::Error>;
 
+    async fn handle_replace(
+        &mut self,
+        ctx: &Context,
+        batch: &Value,
+    ) -> Result<CursorAction, Self::Error> {
+        self.handle_invalidate(&ctx.cursor).await?;
+        self.handle_data(ctx, batch).await
+    }
+
     async fn handle_invalidate(&mut self, cursor: &Option<Cursor>) -> Result<(), Self::Error>;
 
     async fn cleanup(&mut self) -> Result<(), Self::Error> {

--- a/sinks/sink-mongo/CHANGELOG.md
+++ b/sinks/sink-mongo/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2024-03-28
+
+_Add flag to replace pending data inside transaction._
+
+### Added
+
+-   Add `--replace-data-inside-transaction` (env:
+    `MONGO_REPLACE_DATA_INSIDE_TRANSACTION`) flag to replace pending data in one
+    transaction. Notice that MongoDB transactions require a MongoDB deployment with
+    replication turned on.
+
 ## [0.6.2] - 2024-03-21
 
 _Fix issue when transform does not return any data._

--- a/sinks/sink-mongo/Cargo.toml
+++ b/sinks/sink-mongo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-mongo"
-version = "0.6.2"
+version = "0.7.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-mongo/src/configuration.rs
+++ b/sinks/sink-mongo/src/configuration.rs
@@ -19,14 +19,32 @@ pub struct SinkMongoOptions {
         conflicts_with = "collection_names"
     )]
     pub collection_name: Option<String>,
+    /// The collections where to store the data.
+    ///
+    /// If this option is set, the `collection_name` option will be ignored.
+    /// Use this option when writing to multiple collections from the same indexer.
     #[arg(long, env = "MONGO_COLLECTION_NAMES", value_delimiter = ',')]
     pub collection_names: Option<Vec<String>>,
     /// Enable storing records as entities.
     pub entity_mode: Option<bool>,
+    /// Additional conditions to use when invalidating data.
+    ///
+    /// Use this option to run multiple indexers on the same collection.
     #[clap(skip)]
     pub invalidate: Option<Document>,
+    /// The number of seconds to wait before flushing the batch.
+    ///
+    /// If this option is not set, the sink will flush the batch immediately.
     #[arg(long, env = "MONGO_BATCH_SECONDS")]
     pub batch_seconds: Option<u64>,
+    /// Use a transaction to replace pending data.
+    ///
+    /// This option avoids data "flashing" when the previous pending data is replaced.
+    /// Turning this flag on requires a MongoDB replica set. If you are using MongoDB
+    /// Atlas, this is turned on by default. If you're using a standalone MongoDB it
+    /// won't work.
+    #[arg(long, env = "MONGO_REPLACE_DATA_INSIDE_TRANSACTION")]
+    pub replace_data_inside_transaction: Option<bool>,
 }
 
 impl SinkOptions for SinkMongoOptions {
@@ -39,6 +57,9 @@ impl SinkOptions for SinkMongoOptions {
             entity_mode: self.entity_mode.or(other.entity_mode),
             invalidate: self.invalidate.or(other.invalidate),
             batch_seconds: self.batch_seconds.or(other.batch_seconds),
+            replace_data_inside_transaction: self
+                .replace_data_inside_transaction
+                .or(other.replace_data_inside_transaction),
         }
     }
 }

--- a/sinks/sink-mongo/tests/test_multi_collection.rs
+++ b/sinks/sink-mongo/tests/test_multi_collection.rs
@@ -376,11 +376,9 @@ async fn test_handle_data_in_entity_mode() -> Result<(), SinkError> {
     let options = SinkMongoOptions {
         connection_string: Some(format!("mongodb://localhost:{}", port)),
         database: Some("test".into()),
-        collection_name: None,
         collection_names: Some(collection_names.clone()),
         entity_mode: Some(true),
-        invalidate: None,
-        batch_seconds: None,
+        ..Default::default()
     };
 
     let mut sink = MongoSink::from_options(options).await?;
@@ -531,11 +529,9 @@ async fn test_handle_invalidate_in_entity_mode() -> Result<(), SinkError> {
     let options = SinkMongoOptions {
         connection_string: Some(format!("mongodb://localhost:{}", port)),
         database: Some("test".into()),
-        collection_name: None,
         collection_names: Some(collection_names.clone()),
         entity_mode: Some(true),
-        invalidate: None,
-        batch_seconds: None,
+        ..Default::default()
     };
 
     let mut sink = MongoSink::from_options(options).await?;

--- a/sinks/sink-mongo/tests/test_sink.rs
+++ b/sinks/sink-mongo/tests/test_sink.rs
@@ -298,10 +298,8 @@ async fn test_handle_data_in_entity_mode() -> Result<(), SinkError> {
         connection_string: Some(format!("mongodb://localhost:{}", port)),
         database: Some("test".into()),
         collection_name: Some("test".into()),
-        collection_names: None,
         entity_mode: Some(true),
-        invalidate: None,
-        batch_seconds: None,
+        ..Default::default()
     };
 
     let mut sink = MongoSink::from_options(options).await?;
@@ -446,10 +444,8 @@ async fn test_handle_invalidate_in_entity_mode() -> Result<(), SinkError> {
         connection_string: Some(format!("mongodb://localhost:{}", port)),
         database: Some("test".into()),
         collection_name: Some("test".into()),
-        collection_names: None,
         entity_mode: Some(true),
-        invalidate: None,
-        batch_seconds: None,
+        ..Default::default()
     };
 
     let mut sink = MongoSink::from_options(options).await?;
@@ -729,10 +725,8 @@ async fn test_handle_empty_data() -> Result<(), SinkError> {
         connection_string: Some(format!("mongodb://localhost:{}", port)),
         database: Some("test".into()),
         collection_name: Some("test".into()),
-        collection_names: None,
         entity_mode: Some(false),
-        invalidate: None,
-        batch_seconds: None,
+        ..Default::default()
     };
 
     let mut sink = MongoSink::from_options(options).await?;
@@ -762,10 +756,8 @@ async fn test_handle_empty_data_in_entity_mode() -> Result<(), SinkError> {
         connection_string: Some(format!("mongodb://localhost:{}", port)),
         database: Some("test".into()),
         collection_name: Some("test".into()),
-        collection_names: None,
         entity_mode: Some(true),
-        invalidate: None,
-        batch_seconds: None,
+        ..Default::default()
     };
 
     let mut sink = MongoSink::from_options(options).await?;


### PR DESCRIPTION
### Summary

By default, MongoDB handles updating pending data by removing the previous call
data and inserting the new data after that. Sometimes this results in data
"flashing".

This PR adds support for replacing pending data in one transaction. Notice
that this feature requires a special deployment of MongoDB (with replication)
and so it cannot be turned on by default.

### Testing strategy

- Deploy a MongoDB database with replication support.
- Run an indexer that inserts data at every block, for example the ETH
  transfers example in the repo. Use the new `--replace-data-inside-transaction=true`
  flag.
- Data is now always consistent.
