### PR TITLE
starknet: update JSON-RPC to v0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7911,8 +7911,8 @@ dependencies = [
 
 [[package]]
 name = "starknet"
-version = "0.8.0"
-source = "git+https://github.com/fracek/starknet-rs?rev=e6c4a21a7ce5#e6c4a21a7ce53c5fb3faa2f8dc9d71dd5afe4342"
+version = "0.10.0"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=7153d0e42#7153d0e42112f8c1348029557aa6cf2b881a5c84"
 dependencies = [
  "starknet-accounts",
  "starknet-contract",
@@ -7926,8 +7926,8 @@ dependencies = [
 
 [[package]]
 name = "starknet-accounts"
-version = "0.7.0"
-source = "git+https://github.com/fracek/starknet-rs?rev=e6c4a21a7ce5#e6c4a21a7ce53c5fb3faa2f8dc9d71dd5afe4342"
+version = "0.9.0"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=7153d0e42#7153d0e42112f8c1348029557aa6cf2b881a5c84"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -7939,8 +7939,8 @@ dependencies = [
 
 [[package]]
 name = "starknet-contract"
-version = "0.7.0"
-source = "git+https://github.com/fracek/starknet-rs?rev=e6c4a21a7ce5#e6c4a21a7ce53c5fb3faa2f8dc9d71dd5afe4342"
+version = "0.9.0"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=7153d0e42#7153d0e42112f8c1348029557aa6cf2b881a5c84"
 dependencies = [
  "serde",
  "serde_json",
@@ -7953,8 +7953,8 @@ dependencies = [
 
 [[package]]
 name = "starknet-core"
-version = "0.8.0"
-source = "git+https://github.com/fracek/starknet-rs?rev=e6c4a21a7ce5#e6c4a21a7ce53c5fb3faa2f8dc9d71dd5afe4342"
+version = "0.10.0"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=7153d0e42#7153d0e42112f8c1348029557aa6cf2b881a5c84"
 dependencies = [
  "base64 0.21.7",
  "flate2",
@@ -7970,8 +7970,8 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto"
-version = "0.6.1"
-source = "git+https://github.com/fracek/starknet-rs?rev=e6c4a21a7ce5#e6c4a21a7ce53c5fb3faa2f8dc9d71dd5afe4342"
+version = "0.6.2"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=7153d0e42#7153d0e42112f8c1348029557aa6cf2b881a5c84"
 dependencies = [
  "crypto-bigint 0.5.5",
  "hex",
@@ -7989,8 +7989,8 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto-codegen"
-version = "0.3.2"
-source = "git+https://github.com/fracek/starknet-rs?rev=e6c4a21a7ce5#e6c4a21a7ce53c5fb3faa2f8dc9d71dd5afe4342"
+version = "0.3.3"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=7153d0e42#7153d0e42112f8c1348029557aa6cf2b881a5c84"
 dependencies = [
  "starknet-curve",
  "starknet-ff",
@@ -7999,16 +7999,16 @@ dependencies = [
 
 [[package]]
 name = "starknet-curve"
-version = "0.4.0"
-source = "git+https://github.com/fracek/starknet-rs?rev=e6c4a21a7ce5#e6c4a21a7ce53c5fb3faa2f8dc9d71dd5afe4342"
+version = "0.4.2"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=7153d0e42#7153d0e42112f8c1348029557aa6cf2b881a5c84"
 dependencies = [
  "starknet-ff",
 ]
 
 [[package]]
 name = "starknet-ff"
-version = "0.3.6"
-source = "git+https://github.com/fracek/starknet-rs?rev=e6c4a21a7ce5#e6c4a21a7ce53c5fb3faa2f8dc9d71dd5afe4342"
+version = "0.3.7"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=7153d0e42#7153d0e42112f8c1348029557aa6cf2b881a5c84"
 dependencies = [
  "ark-ff",
  "bigdecimal",
@@ -8021,8 +8021,8 @@ dependencies = [
 
 [[package]]
 name = "starknet-macros"
-version = "0.1.5"
-source = "git+https://github.com/fracek/starknet-rs?rev=e6c4a21a7ce5#e6c4a21a7ce53c5fb3faa2f8dc9d71dd5afe4342"
+version = "0.1.7"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=7153d0e42#7153d0e42112f8c1348029557aa6cf2b881a5c84"
 dependencies = [
  "starknet-core",
  "syn 2.0.52",
@@ -8030,8 +8030,8 @@ dependencies = [
 
 [[package]]
 name = "starknet-providers"
-version = "0.8.0"
-source = "git+https://github.com/fracek/starknet-rs?rev=e6c4a21a7ce5#e6c4a21a7ce53c5fb3faa2f8dc9d71dd5afe4342"
+version = "0.10.0"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=7153d0e42#7153d0e42112f8c1348029557aa6cf2b881a5c84"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -8049,8 +8049,8 @@ dependencies = [
 
 [[package]]
 name = "starknet-signers"
-version = "0.6.0"
-source = "git+https://github.com/fracek/starknet-rs?rev=e6c4a21a7ce5#e6c4a21a7ce53c5fb3faa2f8dc9d71dd5afe4342"
+version = "0.8.0"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=7153d0e42#7153d0e42112f8c1348029557aa6cf2b881a5c84"
 dependencies = [
  "async-trait",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,8 +80,8 @@ reqwest = { version = "0.11.16", default-features = false, features = [
 regex = "1.9.1"
 serde = "1.0.155"
 serde_json = "1.0.94"
-# starknet = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "6cadb1986" }
-starknet = { git = "https://github.com/fracek/starknet-rs", rev = "e6c4a21a7ce5" }
+starknet = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "7153d0e42" }
+# starknet = { git = "https://github.com/fracek/starknet-rs", rev = "e6c4a21a7ce5" }
 thiserror = "1.0.32"
 tempfile = "3.3.0"
 tempdir = "0.3.7"

--- a/core/proto/starknet/v1alpha2/starknet.proto
+++ b/core/proto/starknet/v1alpha2/starknet.proto
@@ -42,6 +42,19 @@ message BlockHeader {
   string starknet_version = 7;
   // Price of L1 gas in the block.
   ResourcePrice l1_gas_price = 8;
+  // Price of L1 data gas in the block.
+  ResourcePrice l1_data_gas_price = 9;
+  // L1 data availability mode.
+  L1DataAvailabilityMode l1_data_availability_mode = 10;
+}
+
+enum L1DataAvailabilityMode {
+  // Unknown DA.
+  L1_DATA_AVAILABILITY_MODE_UNSPECIFIED = 0;
+  // Data published via blobs.
+  L1_DATA_AVAILABILITY_MODE_BLOB = 1;
+  // Data published via calldata.
+  L1_DATA_AVAILABILITY_MODE_CALLDATA = 2;
 }
 
 // Status of a block.
@@ -228,7 +241,7 @@ message TransactionReceipt {
   // Transaction's indexe in the list of transactions in a block.
   uint64 transaction_index = 2;
   // Feed paid.
-  FieldElement actual_fee = 3 [ deprecated = true ];
+  FieldElement actual_fee = 3;
   // Messages sent to L1 in the transactions.
   repeated L2ToL1Message l2_to_l1_messages = 4;
   // Events emitted in the transaction.
@@ -241,6 +254,8 @@ message TransactionReceipt {
   string revert_reason = 8;
   // Feed paid.
   FeePayment actual_fee_paid = 9;
+  // The resources consumed by the transaction.
+  ExecutionResources execution_resources = 10;
 }
 
 // Message sent from L2 to L1 together with its transaction and receipt.
@@ -391,6 +406,45 @@ enum PriceUnit {
   PRICE_UNIT_WEI = 1;
   // FRI.
   PRICE_UNIT_FRI = 2;
+}
+
+// Execution resources.
+message ExecutionResources {
+  // Computation resources.
+  ComputationResources computation = 1;
+  // Data availability resources.
+  DataAvailabilityResources data_availability = 2;
+}
+
+// Computation resources.
+message ComputationResources {
+  // The number of Cairo steps used.
+  uint64 steps = 1;
+  // The number of unused memory cells.
+  uint64 memory_holes = 2;
+  // The number of RANGE_CHECK builtin instances.
+  uint64 range_check_builtin_applications = 3;
+  // The number of Pedersen builtin instances.
+  uint64 pedersen_builtin_applications = 4;
+  // The number of Poseidon builtin instances.
+  uint64 poseidon_builtin_applications = 5;
+  // The number of EC_OP builtin instances.
+  uint64 ec_op_builtin_applications = 6;
+  // The number of ECDSA builtin instances.
+  uint64 ecdsa_builtin_applications = 7;
+  // The number of BITWISE builtin instances.
+  uint64 bitwise_builtin_applications = 8;
+  // The number of KECCAK builtin instances.
+  uint64 keccak_builtin_applications = 9;
+  // The number of accesses to the segment arena.
+  uint64 segment_arena_builtin = 10;
+}
+
+message DataAvailabilityResources {
+  // The gas consumed by this transaction's data, 0 if it uses data gas for DA.
+  uint64 l1_gas = 1;
+  // The data gas consumed by this transaction's data, 0 if it uses gas for DA.
+  uint64 l1_data_gas = 2;
 }
 
 message ResourceBoundsMapping {


### PR DESCRIPTION
### Summary

Add the new fields on block header and transaction receipts introduced in RPC v0.7.1.

### Testing strategy

Run `apibara-starknet` and point it to a Starknet node that implements the RPC v0.7.1 spec.
The executable should be able to ingest data without any error.
