### PR TITLE
release: sink-{console, mongo, parquet, postgres, webhook}

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-console"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-mongo"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-parquet"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-postgres"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-webhook"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "apibara-core",
  "apibara-observability",

--- a/sinks/sink-console/CHANGELOG.md
+++ b/sinks/sink-console/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2024-04-09
+
+_Support Starknet 0.13.1 and the new RPC 0.7.1 data._
+
+### Added
+
+-   Add the new blob-related fields in the Starknet RPC 0.7.1 spec.
+-   Add fields related to execution resources in `TransactionReceipt`.
+
 ## [0.4.5] - 2024-03-21
 
 _Update dependencies used to build the binary._

--- a/sinks/sink-console/Cargo.toml
+++ b/sinks/sink-console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-console"
-version = "0.4.5"
+version = "0.5.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-mongo/CHANGELOG.md
+++ b/sinks/sink-mongo/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2024-04-09
+
+_Support Starknet 0.13.1 and the new RPC 0.7.1 data._
+
+### Added
+
+-   Add the new blob-related fields in the Starknet RPC 0.7.1 spec.
+-   Add fields related to execution resources in `TransactionReceipt`.
+
 ## [0.7.0] - 2024-03-28
 
 _Add flag to replace pending data inside transaction._

--- a/sinks/sink-mongo/Cargo.toml
+++ b/sinks/sink-mongo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-mongo"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-parquet/CHANGELOG.md
+++ b/sinks/sink-parquet/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2024-04-09
+
+_Support Starknet 0.13.1 and the new RPC 0.7.1 data._
+
+### Added
+
+-   Add the new blob-related fields in the Starknet RPC 0.7.1 spec.
+-   Add fields related to execution resources in `TransactionReceipt`.
+
 ## [0.5.2] - 2024-03-21
 
 _Add support for secure Redis persistence._

--- a/sinks/sink-parquet/Cargo.toml
+++ b/sinks/sink-parquet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-parquet"
-version = "0.5.2"
+version = "0.6.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-postgres/CHANGELOG.md
+++ b/sinks/sink-postgres/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2024-04-09
+
+_Support Starknet 0.13.1 and the new RPC 0.7.1 data._
+
+### Added
+
+-   Add the new blob-related fields in the Starknet RPC 0.7.1 spec.
+-   Add fields related to execution resources in `TransactionReceipt`.
+
 ## [0.6.2] - 2024-03-21
 
 _Add support for secure Redis persistence._

--- a/sinks/sink-postgres/Cargo.toml
+++ b/sinks/sink-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-postgres"
-version = "0.6.2"
+version = "0.7.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-webhook/CHANGELOG.md
+++ b/sinks/sink-webhook/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2024-04-09
+
+_Support Starknet 0.13.1 and the new RPC 0.7.1 data._
+
+### Added
+
+-   Add the new blob-related fields in the Starknet RPC 0.7.1 spec.
+-   Add fields related to execution resources in `TransactionReceipt`.
+
 ## [0.5.2] - 2024-03-21
 
 _Add support for secure Redis persistence._

--- a/sinks/sink-webhook/Cargo.toml
+++ b/sinks/sink-webhook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-webhook"
-version = "0.5.2"
+version = "0.6.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
### Summary

- sink-console: v0.5.0
- sink-mongo: v0.8.0
- sink-parquet: v0.6.0
- sink-postgres: v0.7.0
- sink-webhook: v0.6.0

