### PR TITLE
cli: control fp precision in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "apibara-cli"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "apibara-core",
  "apibara-observability",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,7 @@ dependencies = [
  "colored",
  "dirs",
  "error-stack",
+ "float-cmp",
  "futures 0.3.30",
  "octocrab",
  "reqwest",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2024-05-23
+
+_Improve `apibara test` command when working with floating point numbers._
+
+### Added
+
+-   Add a `testOptions` section to `apibara test` snapshots.
+-   Add the `testOptions.floatingPointDecimals` option to control up to how many
+    decimal places to compare floating point numbers in snapshots.
+
 ## [0.4.2] - 2024-01-19
 
 _Allow network access._

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -36,3 +36,4 @@ similar-asserts = { version = "1.4.2", features = [
 walkdir = "2.3.3"
 tracing.workspace = true
 tempfile.workspace = true
+float-cmp = "0.9.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-cli"
-version = "0.4.2"
+version = "0.5.0"
 edition.workspace = true
 license.workspace = true
 

--- a/cli/src/test/compare.rs
+++ b/cli/src/test/compare.rs
@@ -1,0 +1,67 @@
+use float_cmp::approx_eq;
+use serde_json::Value;
+
+use super::snapshot::TestOptions;
+
+const DEFAULT_FP_DECIMALS: i64 = 20;
+
+/// Compare two outputs, taking into account test options like floating point precision.
+pub fn outputs_are_equal(expected: &Value, actual: &Value, options: &TestOptions) -> bool {
+    let visitor = EqualityVisitor::from_options(options);
+    visitor.eq(expected, actual)
+}
+
+struct EqualityVisitor {
+    floating_point_decimals: Option<i64>,
+}
+
+impl EqualityVisitor {
+    pub fn from_options(options: &TestOptions) -> Self {
+        Self {
+            floating_point_decimals: options.floating_point_decimals,
+        }
+    }
+
+    pub fn eq(&self, expected: &Value, actual: &Value) -> bool {
+        match (expected, actual) {
+            (Value::Number(expected), Value::Number(actual)) => self.number_eq(expected, actual),
+            (Value::Array(expected), Value::Array(actual)) => self.array_eq(expected, actual),
+            (Value::Object(expected), Value::Object(actual)) => self.object_eq(expected, actual),
+            (expected, actual) => expected == actual,
+        }
+    }
+
+    fn number_eq(&self, expected: &serde_json::Number, actual: &serde_json::Number) -> bool {
+        let decimals = self.floating_point_decimals.unwrap_or(DEFAULT_FP_DECIMALS);
+
+        match (expected.as_f64(), actual.as_f64()) {
+            (Some(expected), Some(actual)) => {
+                let epsilon = 10.0_f64.powi(-decimals as i32);
+                approx_eq!(f64, expected, actual, epsilon = epsilon)
+            }
+            _ => expected == actual,
+        }
+    }
+
+    fn array_eq(&self, expected: &[Value], actual: &[Value]) -> bool {
+        expected.len() == actual.len()
+            && expected
+                .iter()
+                .zip(actual.iter())
+                .all(|(expected, actual)| self.eq(expected, actual))
+    }
+
+    fn object_eq(
+        &self,
+        expected: &serde_json::Map<String, Value>,
+        actual: &serde_json::Map<String, Value>,
+    ) -> bool {
+        expected.len() == actual.len()
+            && expected
+                .iter()
+                .all(|(key, expected)| match actual.get(key) {
+                    Some(actual) => self.eq(expected, actual),
+                    None => false,
+                })
+    }
+}

--- a/cli/src/test/mod.rs
+++ b/cli/src/test/mod.rs
@@ -7,6 +7,7 @@ use tracing::warn;
 
 use crate::error::CliError;
 
+mod compare;
 mod error;
 mod run;
 mod snapshot;

--- a/cli/src/test/snapshot.rs
+++ b/cli/src/test/snapshot.rs
@@ -13,12 +13,21 @@ use tracing::debug;
 use crate::{error::CliError, test::SNAPSHOTS_DIR};
 
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct Snapshot {
     pub script_path: PathBuf,
     pub num_batches: usize,
     pub stream_options: StreamOptions,
     pub stream_configuration_options: StreamConfigurationOptions,
+    pub test_options: TestOptions,
     pub stream: Vec<Value>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TestOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub floating_point_decimals: Option<i64>,
 }
 
 pub struct SnapshotGenerator {
@@ -167,6 +176,7 @@ impl SnapshotGenerator {
             num_batches: self.num_batches,
             stream_options,
             stream_configuration_options: self.stream_configuration_options,
+            test_options: TestOptions::default(),
             stream,
         })
     }

--- a/examples/common/starknet.js
+++ b/examples/common/starknet.js
@@ -22,9 +22,7 @@ export const filter = {
     {
       fromAddress:
         "0x049D36570D4e46f48e99674bd3fcc84644DdD6b96F7C741B1562B82f9e004dC7",
-      keys: [
-        hash.getSelectorFromName("Transfer"),
-      ],
+      keys: [hash.getSelectorFromName("Transfer")],
       includeReceipt: false,
     },
   ],

--- a/sinks/sink-common/src/configuration.rs
+++ b/sinks/sink-common/src/configuration.rs
@@ -160,7 +160,7 @@ pub struct StreamConfigurationOptions {
     pub starting_block: Option<u64>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(tag = "network", content = "filter", rename_all = "camelCase")]
 pub enum NetworkFilterOptions {
     Starknet(v1alpha2::Filter),


### PR DESCRIPTION
### Summary

One obstacle to the adoption of the `apibara test` command was that floating
point numbers were compared using strict equality. This resulted in _a lot_ of
false positives.

We add a new option to snapshots to control the floating point precision
(specifying the number of decimals to compare) used for equality comparison.

After generating the snapshot, users can edit it to change the
`testOptions.floatingPointDecimals` option to the required precision.

### Testing strategy

You can test by running the `apibara test` command on one of the example indexers:

- `cargo run -p apibara-cli -- test examples/postgres/starknet_to_postgres.js`.
- Open `snapshots/starknet_to_postgres.json` and check the `testOptions` section.
- Update that value to the desired number of decimals.
- Rerun the test and verify it succeeds.
