### PR TITLE
starknet: add jemalloc feature

### DIFF
--- a/starknet/Cargo.toml
+++ b/starknet/Cargo.toml
@@ -14,6 +14,10 @@ path = "src/lib.rs"
 name = "apibara-starknet"
 path = "src/bin.rs"
 
+[features]
+default = ["jemalloc"]
+jemalloc = ["dep:jemallocator"]
+
 [dependencies]
 apibara-core = { path = "../core" }
 apibara-node = { path = "../node" }
@@ -48,9 +52,7 @@ tracing.workspace = true
 tracing-futures.workspace = true
 url = "2.2.2"
 warp.workspace = true
-
-[target.'cfg(not(windows))'.dependencies]
-jemallocator.workspace = true
+jemallocator = { workspace = true, optional = true }
 
 [dev-dependencies]
 apibara-core = { path = "../core" }

--- a/starknet/src/bin.rs
+++ b/starknet/src/bin.rs
@@ -4,7 +4,7 @@ use clap::{Parser, Subcommand};
 use error_stack::{Result, ResultExt};
 use tokio_util::sync::CancellationToken;
 
-#[cfg(not(windows))]
+#[cfg(feature = "jemalloc")]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 


### PR DESCRIPTION
### Summary

This PR makes the allocator used by the Starknet DNA server configurable.
Developers can disable jemalloc by building the project with the
`--disable-default-features` flag.
