### PR TITLE
Allow all environment variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-console"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-mongo"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-parquet"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-postgres"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "apibara-core",
  "apibara-observability",
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-sink-webhook"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "apibara-core",
  "apibara-observability",

--- a/script/src/script.rs
+++ b/script/src/script.rs
@@ -362,6 +362,7 @@ impl Script {
     }
 
     fn default_permissions(options: &ScriptOptions) -> Result<PermissionsContainer, ScriptError> {
+        let allow_env = options.allow_env.clone().map(remove_empty_strings);
         // If users use an empty hostname, allow all hosts.
         let allow_net = options.allow_net.clone().map(remove_empty_strings);
         let allow_read = options.allow_read.clone().map(|paths| {
@@ -378,7 +379,7 @@ impl Script {
         });
 
         match Permissions::from_options(&PermissionsOptions {
-            allow_env: options.allow_env.clone(),
+            allow_env,
             allow_hrtime: true,
             allow_net,
             allow_read,

--- a/sinks/sink-console/CHANGELOG.md
+++ b/sinks/sink-console/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2024-06-10
+
+_Simplify access to all environment variables._
+
+### Changed
+
+-   If the argument to `--allow-env-from-env` is an empty string, grant access to
+    all environment variables.
+
 ## [0.5.0] - 2024-04-09
 
 _Support Starknet 0.13.1 and the new RPC 0.7.1 data._

--- a/sinks/sink-console/Cargo.toml
+++ b/sinks/sink-console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-console"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-mongo/CHANGELOG.md
+++ b/sinks/sink-mongo/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2024-06-10
+
+_Simplify access to all environment variables._
+
+### Changed
+
+-   If the argument to `--allow-env-from-env` is an empty string, grant access to
+    all environment variables.
+
 ## [0.8.0] - 2024-04-09
 
 _Support Starknet 0.13.1 and the new RPC 0.7.1 data._

--- a/sinks/sink-mongo/Cargo.toml
+++ b/sinks/sink-mongo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-mongo"
-version = "0.8.0"
+version = "0.9.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-parquet/CHANGELOG.md
+++ b/sinks/sink-parquet/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2024-06-10
+
+_Simplify access to all environment variables._
+
+### Changed
+
+-   If the argument to `--allow-env-from-env` is an empty string, grant access to
+    all environment variables.
+
 ## [0.6.0] - 2024-04-09
 
 _Support Starknet 0.13.1 and the new RPC 0.7.1 data._

--- a/sinks/sink-parquet/Cargo.toml
+++ b/sinks/sink-parquet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-parquet"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-postgres/CHANGELOG.md
+++ b/sinks/sink-postgres/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2024-06-10
+
+_Simplify access to all environment variables._
+
+### Changed
+
+-   If the argument to `--allow-env-from-env` is an empty string, grant access to
+    all environment variables.
+
 ## [0.7.0] - 2024-04-09
 
 _Support Starknet 0.13.1 and the new RPC 0.7.1 data._

--- a/sinks/sink-postgres/Cargo.toml
+++ b/sinks/sink-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-postgres"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/sinks/sink-webhook/CHANGELOG.md
+++ b/sinks/sink-webhook/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2024-06-10
+
+_Simplify access to all environment variables._
+
+### Changed
+
+-   If the argument to `--allow-env-from-env` is an empty string, grant access to
+    all environment variables.
+
 ## [0.6.0] - 2024-04-09
 
 _Support Starknet 0.13.1 and the new RPC 0.7.1 data._

--- a/sinks/sink-webhook/Cargo.toml
+++ b/sinks/sink-webhook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-sink-webhook"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
### Summary

This PR adds a shortcut to allow accessing all environment variables by
specifying an empty string.
