### PR TITLE
Fix crash when overriding starking block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-starknet"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "apibara-core",
  "apibara-node",

--- a/starknet/CHANGELOG.md
+++ b/starknet/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Common Changelog](https://common-changelog.org/), and
 this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.2] - 2024-09-03
+
+_Fix crash when overriding the ingestion starting block._
+
+### Fixed
+
+-   Fix `InconsistentDatabase` error when overriding the ingestion starting block.
+
 ## [1.6.1] - 2024-07-31
 
 _Support filtering invoke transactions v3._

--- a/starknet/Cargo.toml
+++ b/starknet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-starknet"
-version = "1.6.1"
+version = "1.6.2"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/starknet/src/ingestion/accepted.rs
+++ b/starknet/src/ingestion/accepted.rs
@@ -83,7 +83,15 @@ where
             .await
             .map_err(BlockIngestionError::provider)?;
 
-        let finalized = self.storage.highest_finalized_block()?;
+        let finalized = if let Some(starting_block) = self.config.ingestion_starting_block {
+            warn!("starting block is set, using it as finalized block");
+            self.storage
+                .highest_finalized_block()?
+                .unwrap_or(GlobalBlockId::from_u64(starting_block))
+                .into()
+        } else {
+            self.storage.highest_finalized_block()?
+        };
 
         let ingestion = AcceptedBlockIngestionImpl {
             current_head,


### PR DESCRIPTION
### Summary

Some users reported an `InconsistentDatabase` error when running
`apibara-starknet` together with devnet and mainnet forking.

This issue was caused by the ingestion service expecting blocks to
be ingested sequentially, starting from block 0.

This fix changes the ingestion service to consider the specified starting block
(if any) as finalized.

### Testing strategy

- Start `starknet-devnet-rs` with mainnet forking (e.g. `--chain-id MAINNET --fork-block 657000`)
- Start `apibara-starknet` ingesting data from devnet and by setting `--dangerously-override-ingestion-start-block=657065`

Notice how before this PR the ingestion process fails, but with this patch it works.
