### PR TITLE
Test and improve reorg handling

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,6 @@
+[profile.default]
+default-filter = 'all()'
+
+[profile.ci]
+default-filter = 'not binary(test_ingestion_service)'
+fail-fast = false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,6 +593,11 @@ dependencies = [
 name = "apibara-dna-common"
 version = "0.0.0"
 dependencies = [
+ "alloy-provider",
+ "alloy-rpc-client",
+ "alloy-rpc-types",
+ "alloy-transport",
+ "alloy-transport-http",
  "anyhow",
  "apibara-dna-protocol",
  "apibara-etcd",
@@ -612,8 +617,10 @@ dependencies = [
  "memmap2",
  "prost",
  "rand 0.8.5",
+ "reqwest 0.12.8",
  "rkyv 0.8.8",
  "roaring",
+ "serde_json",
  "tempdir",
  "tempfile",
  "testcontainers",
@@ -624,6 +631,7 @@ dependencies = [
  "tonic-health",
  "tonic-reflection",
  "tracing",
+ "url",
  "valuable",
  "zstd",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.5"
+version = "2.0.0-beta.6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.5"
+version = "2.0.0-beta.6"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.5"
+version = "2.0.0-beta.6"
 dependencies = [
  "apibara-dna-common",
  "apibara-dna-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,11 @@ incremental = false
 [workspace.dependencies]
 alloy-primitives = "0.8"
 alloy-eips = "0.3.6"
+alloy-rpc-client = "0.3.6"
+alloy-provider = "0.3.6"
+alloy-rpc-types = "0.3.6"
+alloy-transport = "0.3.6"
+alloy-transport-http = "0.3.6"
 bytes = { version = "1.7.1", features = ["serde"] }
 byte-unit = "5.1.4"
 clap = { version = "4.5.13", features = [

--- a/beaconchain/Cargo.toml
+++ b/beaconchain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.5"
+version = "2.0.0-beta.6"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/beaconchain/src/provider/http.rs
+++ b/beaconchain/src/provider/http.rs
@@ -38,6 +38,10 @@ pub struct BeaconApiProvider {
     options: BeaconApiProviderOptions,
 }
 
+pub trait BeaconApiProviderErrorExt {
+    fn is_not_found(&self) -> bool;
+}
+
 #[derive(Debug, Clone)]
 pub struct BeaconApiProviderOptions {
     /// Timeout for normal requests.
@@ -304,5 +308,11 @@ impl Default for BeaconApiProviderOptions {
             validators_timeout: Duration::from_secs(60),
             headers: HeaderMap::default(),
         }
+    }
+}
+
+impl BeaconApiProviderErrorExt for Report<BeaconApiError> {
+    fn is_not_found(&self) -> bool {
+        matches!(self.current_context(), BeaconApiError::NotFound)
     }
 }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -43,6 +43,14 @@ valuable.workspace = true
 zstd.workspace = true
 
 [dev-dependencies]
+alloy-rpc-client.workspace = true
+alloy-provider.workspace = true
+alloy-rpc-types.workspace = true
+alloy-transport.workspace = true
+alloy-transport-http.workspace = true
 rand.workspace = true
+reqwest.workspace = true
+serde_json.workspace = true
 tempfile.workspace = true
 tempdir.workspace = true
+url.workspace = true

--- a/common/src/chain.rs
+++ b/common/src/chain.rs
@@ -19,6 +19,19 @@ impl BlockInfo {
             hash: self.hash.clone(),
         }
     }
+
+    pub fn parent_cursor(&self) -> Option<Cursor> {
+        if self.number == 0 {
+            return None;
+        }
+
+        let cursor = Cursor {
+            number: self.number - 1,
+            hash: self.parent.clone(),
+        };
+
+        Some(cursor)
+    }
 }
 
 /// What action to take on reconnection.
@@ -441,6 +454,27 @@ impl std::fmt::Display for CanonicalChainError {
         match self {
             CanonicalChainError::Builder => write!(f, "canonical chain builder error"),
             CanonicalChainError::View => write!(f, "canonical chain view error"),
+        }
+    }
+}
+
+impl ReconnectAction {
+    pub fn is_continue(&self) -> bool {
+        matches!(self, ReconnectAction::Continue)
+    }
+
+    pub fn is_offline_reorg(&self) -> bool {
+        matches!(self, ReconnectAction::OfflineReorg(_))
+    }
+
+    pub fn is_unknown(&self) -> bool {
+        matches!(self, ReconnectAction::Unknown)
+    }
+
+    pub fn as_offline_reorg_cursor(&self) -> Option<Cursor> {
+        match self {
+            ReconnectAction::OfflineReorg(cursor) => Some(cursor.clone()),
+            _ => None,
         }
     }
 }

--- a/common/src/data_stream/stream.rs
+++ b/common/src/data_stream/stream.rs
@@ -119,6 +119,7 @@ impl DataStream {
 
                 // TODO: collect removed blocks.
                 let invalidate = Message::Invalidate(Invalidate {
+                    cursor: Some(cursor.clone().into()),
                     ..Default::default()
                 });
 

--- a/common/src/ingestion/mod.rs
+++ b/common/src/ingestion/mod.rs
@@ -1,7 +1,7 @@
 mod cli;
 mod error;
 mod service;
-mod state_client;
+pub mod state_client;
 
 use apibara_etcd::{EtcdClient, LockOptions};
 use error_stack::{Result, ResultExt};

--- a/common/src/ingestion/service.rs
+++ b/common/src/ingestion/service.rs
@@ -73,14 +73,14 @@ where
     ingestion: Arc<I>,
 }
 
-enum IngestionState {
+pub enum IngestionState {
     Ingest(IngestState),
     Recover,
 }
 
-struct IngestState {
-    finalized: Cursor,
-    head: Cursor,
+pub struct IngestState {
+    pub finalized: Cursor,
+    pub head: Cursor,
     queued_block_number: u64,
     head_refresh_interval: Interval,
     finalized_refresh_interval: Interval,
@@ -169,7 +169,7 @@ where
         err(Debug),
         fields(head, finalized, starting_block)
     )]
-    async fn initialize(&mut self) -> Result<IngestionState, IngestionError> {
+    pub async fn initialize(&mut self) -> Result<IngestionState, IngestionError> {
         let head = self.ingestion.get_head_cursor().await?;
         let finalized = self.ingestion.get_finalized_cursor().await?;
 
@@ -503,6 +503,13 @@ impl IngestionState {
         match self {
             IngestionState::Recover => "recover",
             IngestionState::Ingest(_) => "ingest",
+        }
+    }
+
+    pub fn as_ingest(&self) -> Option<&IngestState> {
+        match self {
+            IngestionState::Ingest(state) => Some(state),
+            _ => None,
         }
     }
 }

--- a/common/src/ingestion/state_client.rs
+++ b/common/src/ingestion/state_client.rs
@@ -361,6 +361,7 @@ pub mod testing {
                 .get_host_port_ipv4(2379)
                 .await
                 .expect("Etcd port 2379 not found");
+
             let endpoint = format!("http://localhost:{port}");
             EtcdClient::connect(&[endpoint], Default::default())
                 .await

--- a/common/tests/test_ingestion_service.rs
+++ b/common/tests/test_ingestion_service.rs
@@ -868,7 +868,7 @@ pub mod testing {
 
     impl Image for AnvilServer {
         fn name(&self) -> &str {
-            "anvil"
+            "quay.io/fracek/anvil"
         }
 
         fn tag(&self) -> &str {

--- a/common/tests/test_ingestion_service.rs
+++ b/common/tests/test_ingestion_service.rs
@@ -1,0 +1,303 @@
+use std::sync::Arc;
+
+use alloy_rpc_types::BlockNumberOrTag;
+use apibara_etcd::EtcdClient;
+use error_stack::Result;
+use foyer::HybridCacheBuilder;
+use testcontainers::{runners::AsyncRunner, ContainerAsync};
+
+use apibara_dna_common::{
+    chain::BlockInfo,
+    file_cache::FileCache,
+    fragment,
+    ingestion::{
+        state_client::testing::{etcd_server_container, EtcdServer, EtcdServerExt},
+        BlockIngestion, IngestionError, IngestionService, IngestionServiceOptions,
+        IngestionStateClient,
+    },
+    object_store::{
+        testing::{minio_container, MinIO, MinIOExt},
+        ObjectStore, ObjectStoreOptions,
+    },
+    Cursor, Hash,
+};
+use testing::{
+    anvil_server_container, AnvilProvider, AnvilProviderExt, AnvilServer, AnvilServerExt,
+};
+
+async fn init_minio() -> (ContainerAsync<MinIO>, ObjectStore) {
+    let minio = minio_container().start().await.unwrap();
+    let config = minio.s3_config().await;
+
+    let client = ObjectStore::new_from_config(
+        config,
+        ObjectStoreOptions {
+            bucket: "test".to_string(),
+            ..Default::default()
+        },
+    );
+
+    client.ensure_bucket().await.unwrap();
+
+    (minio, client)
+}
+
+async fn init_etcd_server() -> (ContainerAsync<EtcdServer>, EtcdClient) {
+    let etcd_server = etcd_server_container().start().await.unwrap();
+    let etcd_client = etcd_server.etcd_client().await;
+
+    (etcd_server, etcd_client)
+}
+
+async fn init_anvil() -> (ContainerAsync<AnvilServer>, Arc<AnvilProvider>) {
+    let anvil_server = anvil_server_container().start().await.unwrap();
+
+    let provider = anvil_server.alloy_provider().await;
+    (anvil_server, provider)
+}
+
+async fn init_file_cache() -> FileCache {
+    HybridCacheBuilder::default()
+        .memory(1024 * 1024)
+        .storage(foyer::Engine::Large)
+        .build()
+        .await
+        .expect("failed to create file cache")
+}
+
+#[tokio::test]
+async fn test_ingestion_initialize() {
+    let (_minio, object_store) = init_minio().await;
+    let (_etcd_server, etcd_client) = init_etcd_server().await;
+    let (_anvil_server, anvil_provider) = init_anvil().await;
+
+    let mut state_client = IngestionStateClient::new(&etcd_client);
+    let file_cache = init_file_cache().await;
+
+    let block_ingestion = TestBlockIngestion {
+        provider: anvil_provider.clone(),
+    };
+
+    let mut service = IngestionService::new(
+        block_ingestion,
+        etcd_client,
+        object_store,
+        file_cache,
+        IngestionServiceOptions::default(),
+    );
+
+    anvil_provider.anvil_mine(100, 3).await;
+    let header = anvil_provider.get_header(BlockNumberOrTag::Latest).await;
+    assert_eq!(header.number, 100);
+
+    let starting_state = service.initialize().await.unwrap();
+    let ingest_state = starting_state.as_ingest().unwrap();
+
+    assert_eq!(ingest_state.head.number, 100);
+
+    let starting_block = state_client.get_starting_block().await.unwrap();
+    assert_eq!(starting_block, Some(0));
+
+    let finalized = state_client.get_finalized().await.unwrap();
+    assert!(finalized.is_some());
+    assert_eq!(ingest_state.finalized.number, finalized.unwrap());
+
+    // Ingested is updated only after a chain segment is uploaded.
+    let ingested = state_client.get_ingested().await.unwrap();
+    assert!(ingested.is_none());
+}
+
+#[tokio::test]
+async fn test_ingestion_initialize_with_starting_block() {
+    let (_minio, object_store) = init_minio().await;
+    let (_etcd_server, etcd_client) = init_etcd_server().await;
+    let (_anvil_server, anvil_provider) = init_anvil().await;
+
+    let mut state_client = IngestionStateClient::new(&etcd_client);
+    let file_cache = init_file_cache().await;
+
+    let block_ingestion = TestBlockIngestion {
+        provider: anvil_provider.clone(),
+    };
+
+    let options = IngestionServiceOptions {
+        override_starting_block: Some(100),
+        ..Default::default()
+    };
+
+    let mut service = IngestionService::new(
+        block_ingestion,
+        etcd_client,
+        object_store,
+        file_cache,
+        options,
+    );
+
+    anvil_provider.anvil_mine(200, 3).await;
+    let header = anvil_provider.get_header(BlockNumberOrTag::Latest).await;
+    assert_eq!(header.number, 200);
+
+    let starting_state = service.initialize().await.unwrap();
+    let ingest_state = starting_state.as_ingest().unwrap();
+
+    assert_eq!(ingest_state.head.number, 200);
+
+    let starting_block = state_client.get_starting_block().await.unwrap();
+    assert_eq!(starting_block, Some(100));
+
+    let finalized = state_client.get_finalized().await.unwrap();
+    assert!(finalized.is_some());
+    assert_eq!(ingest_state.finalized.number, finalized.unwrap());
+
+    // Ingested is updated only after a chain segment is uploaded.
+    let ingested = state_client.get_ingested().await.unwrap();
+    assert!(ingested.is_none());
+}
+
+#[derive(Clone)]
+struct TestBlockIngestion {
+    provider: Arc<AnvilProvider>,
+}
+
+impl BlockIngestion for TestBlockIngestion {
+    async fn get_head_cursor(&self) -> Result<Cursor, IngestionError> {
+        let header = self.provider.get_header(BlockNumberOrTag::Latest).await;
+        let hash = Hash(header.hash.to_vec());
+        Ok(Cursor::new(header.number, hash))
+    }
+
+    async fn get_finalized_cursor(&self) -> Result<Cursor, IngestionError> {
+        let header = self.provider.get_header(BlockNumberOrTag::Finalized).await;
+        let hash = Hash(header.hash.to_vec());
+        Ok(Cursor::new(header.number, hash))
+    }
+
+    async fn get_block_info_by_number(&self, number: u64) -> Result<BlockInfo, IngestionError> {
+        let header = self
+            .provider
+            .get_header(BlockNumberOrTag::Number(number))
+            .await;
+        let hash = Hash(header.hash.to_vec());
+        let parent_hash = Hash(header.parent_hash.to_vec());
+
+        Ok(BlockInfo {
+            number,
+            hash,
+            parent: parent_hash,
+        })
+    }
+
+    async fn ingest_block_by_number(
+        &self,
+        number: u64,
+    ) -> Result<(BlockInfo, fragment::Block), IngestionError> {
+        let info = self.get_block_info_by_number(number).await?;
+
+        let header = fragment::HeaderFragment {
+            data: Vec::default(),
+        };
+        let index = fragment::IndexGroupFragment {
+            indexes: Vec::default(),
+        };
+        let join = fragment::JoinGroupFragment {
+            joins: Vec::default(),
+        };
+
+        let block = fragment::Block {
+            header,
+            index,
+            join,
+            body: Vec::default(),
+        };
+
+        Ok((info, block))
+    }
+}
+
+pub mod testing {
+    use std::sync::Arc;
+
+    use alloy_provider::{network::Ethereum, Provider, ProviderBuilder, RootProvider};
+    use alloy_rpc_client::ClientBuilder;
+    use alloy_rpc_types::{BlockId, BlockNumberOrTag, BlockTransactionsKind, Header};
+    use alloy_transport_http::Http;
+    use futures::Future;
+    use reqwest::Client;
+    use testcontainers::{core::ContainerPort, ContainerAsync, Image};
+    use url::Url;
+
+    pub struct AnvilServer;
+
+    pub type AnvilProvider = RootProvider<Http<Client>, Ethereum>;
+
+    pub trait AnvilServerExt {
+        fn alloy_provider(&self) -> impl Future<Output = Arc<AnvilProvider>> + Send;
+    }
+
+    pub trait AnvilProviderExt {
+        fn anvil_mine(
+            &self,
+            block_count: u64,
+            interval_sec: u64,
+        ) -> impl Future<Output = ()> + Send;
+
+        fn get_header(&self, block: BlockNumberOrTag) -> impl Future<Output = Header> + Send;
+    }
+
+    impl Image for AnvilServer {
+        fn name(&self) -> &str {
+            "anvil"
+        }
+
+        fn tag(&self) -> &str {
+            "latest"
+        }
+
+        fn expose_ports(&self) -> &[ContainerPort] {
+            &[ContainerPort::Tcp(8545)]
+        }
+
+        fn ready_conditions(&self) -> Vec<testcontainers::core::WaitFor> {
+            Vec::default()
+        }
+    }
+
+    pub fn anvil_server_container() -> AnvilServer {
+        AnvilServer
+    }
+
+    impl AnvilServerExt for ContainerAsync<AnvilServer> {
+        async fn alloy_provider(&self) -> Arc<AnvilProvider> {
+            let port = self
+                .get_host_port_ipv4(8545)
+                .await
+                .expect("Anvil port 8545 not found");
+
+            let url: Url = format!("http://localhost:{port}").parse().unwrap();
+            let client = ClientBuilder::default().http(url);
+            let provider = ProviderBuilder::default().on_client(client);
+
+            Arc::new(provider)
+        }
+    }
+
+    impl AnvilProviderExt for Arc<AnvilProvider> {
+        async fn anvil_mine(&self, block_count: u64, interval_sec: u64) {
+            self.raw_request::<_, serde_json::Value>(
+                "anvil_mine".into(),
+                &(block_count, interval_sec),
+            )
+            .await
+            .expect("anvil_mine request failed");
+        }
+
+        async fn get_header(&self, block: BlockNumberOrTag) -> Header {
+            let response = self
+                .get_block(BlockId::Number(block), BlockTransactionsKind::Hashes)
+                .await
+                .expect("get_header request failed")
+                .expect("get_header block missing");
+            response.header
+        }
+    }
+}

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.5"
+version = "2.0.0-beta.6"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -15,11 +15,11 @@ name = "apibara-dna-evm"
 path = "src/bin.rs"
 
 [dependencies]
-alloy-rpc-client = "0.3.6"
-alloy-provider = "0.3.6"
+alloy-rpc-client.workspace = true
+alloy-provider.workspace = true
 alloy-primitives.workspace = true
-alloy-rpc-types = "0.3.6"
-alloy-transport = "0.3.6"
+alloy-rpc-types.workspace = true
+alloy-transport.workspace = true
 apibara-observability = { path = "../observability" }
 apibara-dna-common = { path = "../common" }
 apibara-dna-protocol = { path = "../protocol" }

--- a/evm/src/provider/http.rs
+++ b/evm/src/provider/http.rs
@@ -4,7 +4,7 @@ use alloy_primitives::BlockHash;
 use alloy_provider::{network::Ethereum, Provider, ProviderBuilder};
 use alloy_rpc_client::ClientBuilder;
 use alloy_transport::BoxTransport;
-use error_stack::{Result, ResultExt};
+use error_stack::{Report, Result, ResultExt};
 use reqwest::header::{HeaderMap, HeaderValue};
 use url::Url;
 
@@ -32,6 +32,10 @@ pub struct JsonRpcProviderOptions {
 pub struct JsonRpcProvider {
     provider: Arc<dyn Provider<BoxTransport, Ethereum>>,
     options: JsonRpcProviderOptions,
+}
+
+pub trait JsonRpcProviderErrorExt {
+    fn is_not_found(&self) -> bool;
 }
 
 impl JsonRpcProvider {
@@ -133,5 +137,11 @@ impl std::fmt::Display for JsonRpcProviderError {
             JsonRpcProviderError::NotFound => write!(f, "not found"),
             JsonRpcProviderError::Configuration => write!(f, "configuration error"),
         }
+    }
+}
+
+impl JsonRpcProviderErrorExt for Report<JsonRpcProviderError> {
+    fn is_not_found(&self) -> bool {
+        matches!(self.current_context(), JsonRpcProviderError::NotFound)
     }
 }

--- a/evm/src/provider/mod.rs
+++ b/evm/src/provider/mod.rs
@@ -1,5 +1,7 @@
 mod http;
 pub mod models;
 
-pub use self::http::{BlockId, JsonRpcProvider, JsonRpcProviderError, JsonRpcProviderOptions};
+pub use self::http::{
+    BlockId, JsonRpcProvider, JsonRpcProviderError, JsonRpcProviderErrorExt, JsonRpcProviderOptions,
+};
 pub use self::models::BlockExt;

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1727316705,
-        "narHash": "sha256-/mumx8AQ5xFuCJqxCIOFCHTVlxHkMT21idpbgbm/TIE=",
+        "lastModified": 1730652660,
+        "narHash": "sha256-+XVYfmVXAiYA0FZT7ijHf555dxCe+AoAT5A6RU+6vSo=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "5b03654ce046b5167e7b0bccbd8244cb56c16f0e",
+        "rev": "a4ca93905455c07cb7e3aca95d4faf7601cba458",
         "type": "github"
       },
       "original": {
@@ -35,16 +35,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727540905,
-        "narHash": "sha256-40J9tW7Y794J7Uw4GwcAKlMxlX2xISBl6IBigo83ih8=",
+        "lastModified": 1730785428,
+        "narHash": "sha256-Zwl8YgTVJTEum+L+0zVAWvXAGbWAuXHax3KzuejaDyo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fbca5e745367ae7632731639de5c21f29c8744ed",
+        "rev": "4aa36568d413aca0ea84a1684d2d46f55dbabad7",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727663505,
-        "narHash": "sha256-83j/GrHsx8GFUcQofKh+PRPz6pz8sxAsZyT/HCNdey8=",
+        "lastModified": 1730860036,
+        "narHash": "sha256-u0sfA4B65Q9cRO3xpIkQ4nldB8isfdIb3rWtsnRZ+Iw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c2099c6c7599ea1980151b8b6247a8f93e1806ee",
+        "rev": "b8eb3aeb21629cbe14968a5e3b1cbaefb0d1b260",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Apibara development environment";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils = {
       url = "github:numtide/flake-utils";
     };

--- a/nix/crates.nix
+++ b/nix/crates.nix
@@ -107,7 +107,7 @@ let
     '';
 
     checkPhaseCargoCommand = ''
-      cargo nextest archive --cargo-profile $CARGO_PROFILE --workspace --archive-format tar-zst --archive-file $out/archive.tar.zst
+      cargo nextest -P ci archive --cargo-profile $CARGO_PROFILE --workspace --archive-format tar-zst --archive-file $out/archive.tar.zst
     '';
   });
 
@@ -364,7 +364,7 @@ in
       let
         runTests = pkgs.writeScriptBin "run-integration-tests" ''
           echo "Using archive at ${integrationTestsArchive}"
-          cargo nextest run \
+          cargo nextest -P ci run \
             --archive-file ${integrationTestsArchive}/archive.tar.zst\
             --workspace-remap=. \
             --test-threads=1 \

--- a/nix/crates.nix
+++ b/nix/crates.nix
@@ -367,6 +367,7 @@ in
           cargo nextest run \
             --archive-file ${integrationTestsArchive}/archive.tar.zst\
             --workspace-remap=. \
+            --test-threads=1 \
             -E 'kind(test)'
         '';
       in

--- a/starknet/Cargo.toml
+++ b/starknet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.5"
+version = "2.0.0-beta.6"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/starknet/src/provider/mod.rs
+++ b/starknet/src/provider/mod.rs
@@ -1,5 +1,8 @@
 mod http;
 pub mod models;
 
-pub use self::http::{BlockId, StarknetProvider, StarknetProviderOptions};
+pub use self::http::{
+    BlockId, StarknetProvider, StarknetProviderError, StarknetProviderErrorExt,
+    StarknetProviderOptions,
+};
 pub use self::models::BlockExt;


### PR DESCRIPTION
### Summary

This PR makes some changes to how reorg are tested handled.
The ingestion service can now fully recover from online and offline reorgs.

### Testing strategy

The PR tests reorgs using anvil. The same strategy can be used to test locally.
