### PR TITLE
Stop sending extra blocks in segment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.6"
+version = "2.0.0-beta.7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.6"
+version = "2.0.0-beta.7"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.6"
+version = "2.0.0-beta.7"
 dependencies = [
  "apibara-dna-common",
  "apibara-dna-protocol",

--- a/beaconchain/Cargo.toml
+++ b/beaconchain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.6"
+version = "2.0.0-beta.7"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/common/src/data_stream/stream.rs
+++ b/common/src/data_stream/stream.rs
@@ -274,6 +274,10 @@ impl DataStream {
 
         // let mut prefetch_tasks = JoinSet::new();
         for block_number in data_bitmap.iter() {
+            if block_number < cursor.number as u32 {
+                continue;
+            }
+
             let block_number = block_number as u64;
 
             if block_number > current_segment_end {
@@ -420,9 +424,15 @@ impl DataStream {
                 break;
             }
 
+            let block_number = starting_block_number + i;
+
+            if block_number < cursor.number {
+                continue;
+            }
+
             let CanonicalCursor::Canonical(next_cursor) = self
                 .chain_view
-                .get_canonical(starting_block_number + i)
+                .get_canonical(block_number)
                 .await
                 .change_context(DataStreamError)?
             else {

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.6"
+version = "2.0.0-beta.7"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/starknet/Cargo.toml
+++ b/starknet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.6"
+version = "2.0.0-beta.7"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
### Summary

Before this PR, blocks in a segment before the starting block would be included in the stream.
This is an issue since the client expects block to start _after_ the specified starting cursor.

This PR fixes this.

