### PR TITLE
Periodically renew ETCD token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.8"
+version = "2.0.0-beta.9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.8"
+version = "2.0.0-beta.9"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.8"
+version = "2.0.0-beta.9"
 dependencies = [
  "apibara-dna-common",
  "apibara-dna-protocol",

--- a/beaconchain/Cargo.toml
+++ b/beaconchain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.8"
+version = "2.0.0-beta.9"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/etcd/src/client.rs
+++ b/etcd/src/client.rs
@@ -1,4 +1,8 @@
+use std::time::Duration;
+
 use error_stack::{Result, ResultExt};
+use tokio_util::sync::CancellationToken;
+use tracing::info;
 
 use crate::{lock::LockOptions, utils::normalize_prefix, watch::WatchClient};
 
@@ -9,13 +13,14 @@ use crate::{kv::KvClient, lock::LockClient};
 #[derive(Debug)]
 pub struct EtcdClientError;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct AuthOptions {
     pub user: String,
     pub password: String,
+    pub token_ttl: Duration,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct EtcdClientOptions {
     pub prefix: Option<String>,
     pub auth: Option<AuthOptions>,
@@ -24,6 +29,7 @@ pub struct EtcdClientOptions {
 #[derive(Clone)]
 pub struct EtcdClient {
     pub(crate) client: etcd_client::Client,
+    auth: Option<AuthOptions>,
     prefix: String,
 }
 
@@ -32,7 +38,7 @@ impl EtcdClient {
         endpoints: S,
         options: EtcdClientOptions,
     ) -> Result<Self, EtcdClientError> {
-        let connect_options = if let Some(auth) = options.auth {
+        let connect_options = if let Some(auth) = options.auth.clone() {
             etcd_client::ConnectOptions::new()
                 .with_user(auth.user, auth.password)
                 .into()
@@ -47,7 +53,40 @@ impl EtcdClient {
 
         let prefix = normalize_prefix(options.prefix);
 
-        Ok(Self { client, prefix })
+        Ok(Self {
+            client,
+            prefix,
+            auth: options.auth,
+        })
+    }
+
+    pub async fn start_renew_auth_token(
+        self,
+        ct: CancellationToken,
+    ) -> Result<(), EtcdClientError> {
+        let mut inner_client = self.client.clone();
+
+        if let Some(auth) = self.auth.clone() {
+            let renew_interval = auth.token_ttl / 2;
+
+            loop {
+                tokio::select! {
+                    _ = ct.cancelled() => {
+                        break;
+                    }
+                    _ = tokio::time::sleep(renew_interval) => {
+                        info!("renewing etcd auth token");
+                        inner_client.set_client_auth(auth.user.clone(), auth.password.clone()).await
+                            .change_context(EtcdClientError)
+                            .attach_printable("failed to renew auth token")?;
+                    }
+                }
+            }
+        } else {
+            ct.cancelled().await;
+        }
+
+        Ok(())
     }
 
     pub async fn status(&mut self) -> Result<StatusResponse, EtcdClientError> {

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.8"
+version = "2.0.0-beta.9"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/starknet/Cargo.toml
+++ b/starknet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.8"
+version = "2.0.0-beta.9"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
### Summary

The Etcd client acquires an authentication upon connection. This token is short lived (default to 5 minutes) and for this reason it needs to be renewed periodically or the client will error.

We are seeing this issue in production, with the DNA process restarting every 5 minutes or so.

