### PR TITLE
Improve starting cursor handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.11"
+version = "2.0.0-beta.12"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.11"
+version = "2.0.0-beta.12"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.11"
+version = "2.0.0-beta.12"
 dependencies = [
  "apibara-dna-common",
  "apibara-dna-protocol",

--- a/beaconchain/Cargo.toml
+++ b/beaconchain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.11"
+version = "2.0.0-beta.12"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/common/src/chain_view/mod.rs
+++ b/common/src/chain_view/mod.rs
@@ -4,6 +4,6 @@ mod sync;
 mod view;
 
 pub use self::error::ChainViewError;
-pub use self::full::{CanonicalCursor, NextCursor};
+pub use self::full::{CanonicalCursor, NextCursor, ValidatedCursor};
 pub use self::sync::{chain_view_sync_loop, ChainViewSyncService};
 pub use self::view::ChainView;

--- a/common/src/chain_view/view.rs
+++ b/common/src/chain_view/view.rs
@@ -7,7 +7,7 @@ use crate::Cursor;
 
 use super::{
     error::ChainViewError,
-    full::{FullCanonicalChain, NextCursor},
+    full::{FullCanonicalChain, NextCursor, ValidatedCursor},
     CanonicalCursor,
 };
 
@@ -104,6 +104,14 @@ impl ChainView {
     ) -> Result<NextCursor, ChainViewError> {
         let inner = self.0.read().await;
         inner.canonical.get_next_cursor(cursor).await
+    }
+
+    pub async fn validate_cursor(
+        &self,
+        cursor: &Cursor,
+    ) -> Result<ValidatedCursor, ChainViewError> {
+        let inner = self.0.read().await;
+        inner.canonical.validate_cursor(cursor).await
     }
 
     pub async fn get_canonical(

--- a/common/src/compaction/group.rs
+++ b/common/src/compaction/group.rs
@@ -60,7 +60,7 @@ impl SegmentGroupService {
                 .await
                 .change_context(CompactionError)?
             {
-                let NextCursor::Continue(cursor) = chain_view
+                let NextCursor::Continue { cursor, .. } = chain_view
                     .get_next_cursor(&Some(cursor.clone()))
                     .await
                     .change_context(CompactionError)?

--- a/common/src/compaction/segment.rs
+++ b/common/src/compaction/segment.rs
@@ -51,7 +51,7 @@ impl SegmentService {
                 .await
                 .change_context(CompactionError)?
             {
-                let NextCursor::Continue(cursor) = chain_view
+                let NextCursor::Continue { cursor, .. } = chain_view
                     .get_next_cursor(&Some(cursor.clone()))
                     .await
                     .change_context(CompactionError)?
@@ -115,7 +115,10 @@ impl SegmentService {
                         .attach_printable("failed to add block to segment")
                         .attach_printable_lazy(|| format!("cursor: {current}"))?;
 
-                    let NextCursor::Continue(next_cursor) = chain_view
+                    let NextCursor::Continue {
+                        cursor: next_cursor,
+                        ..
+                    } = chain_view
                         .get_next_cursor(&Some(current.clone()))
                         .await
                         .change_context(CompactionError)?

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.11"
+version = "2.0.0-beta.12"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/protocol/proto/dna/v2/stream.proto
+++ b/protocol/proto/dna/v2/stream.proto
@@ -106,6 +106,8 @@ message Data {
   //
   // This message contains chain-specific data serialized using protobuf.
   repeated bytes data = 4;
+  // The production mode of the block.
+  DataProduction production = 5;
 }
 
 // Sent to clients to check if stream is still connected.
@@ -130,4 +132,13 @@ enum DataFinality {
   DATA_FINALITY_ACCEPTED = 2;
   // Data is finalized and cannot be invalidated.
   DATA_FINALITY_FINALIZED = 3;
+}
+
+// Data production mode.
+enum DataProduction {
+  DATA_PRODUCTION_UNKNOWN = 0;
+  // Data is for a backfilled block.
+  DATA_PRODUCTION_BACKFILL = 1;
+  // Data is for a live block.
+  DATA_PRODUCTION_LIVE = 2;
 }

--- a/starknet/Cargo.toml
+++ b/starknet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.11"
+version = "2.0.0-beta.12"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
### Summary

This PR improves on the starting cursor handling by:

 - be less strict when comparing cursors by ignoring any 0 prefix in the hash.
 - return the hash of the canonical block on error.
 - signal to user whether the data is a backfill or live block.
