### PR TITLE
Fix issues with missing data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.12"
+version = "2.0.0-beta.13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.12"
+version = "2.0.0-beta.13"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.12"
+version = "2.0.0-beta.13"
 dependencies = [
  "apibara-dna-common",
  "apibara-dna-protocol",

--- a/beaconchain/Cargo.toml
+++ b/beaconchain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.12"
+version = "2.0.0-beta.13"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/common/src/compaction/group.rs
+++ b/common/src/compaction/group.rs
@@ -98,7 +98,7 @@ impl SegmentGroupService {
             if first_block_in_group.number + blocks_in_group <= segmented.number {
                 info!(starting_cursor = %first_block_in_group, "creating new group");
 
-                let mut builder = SegmentGroupBuilder::default();
+                let mut builder = SegmentGroupBuilder::new(self.segment_size);
 
                 for i in 0..self.group_size {
                     let segment_start =

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.12"
+version = "2.0.0-beta.13"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/evm/src/ingestion.rs
+++ b/evm/src/ingestion.rs
@@ -348,7 +348,7 @@ fn collect_block_body_and_index(
 
         let mut transaction_logs_id = Vec::new();
 
-        for log in receipt.inner.logs() {
+        for (log_index_in_transaction, log) in receipt.inner.logs().iter().enumerate() {
             let log_index = block_logs.len() as u32;
 
             if let Some(rpc_log_index) = log.log_index {
@@ -379,6 +379,7 @@ fn collect_block_body_and_index(
             log.transaction_index = transaction_index;
             log.transaction_hash = transaction_hash.into();
             log.transaction_status = transaction_status;
+            log.log_index_in_transaction = log_index_in_transaction as u32;
 
             join_log_to_transaction.insert(log_index, transaction_index);
             join_log_to_receipt.insert(log_index, transaction_index);

--- a/evm/src/proto.rs
+++ b/evm/src/proto.rs
@@ -136,6 +136,7 @@ impl ModelExt for models::Log {
             transaction_index: u32::MAX,
             transaction_hash: None,
             transaction_status: 0,
+            log_index_in_transaction: u32::MAX,
         }
     }
 }

--- a/protocol/proto/evm/v2/data.proto
+++ b/protocol/proto/evm/v2/data.proto
@@ -175,6 +175,8 @@ message Log {
   B256 transaction_hash = 7;
   // The transaction status.
   TransactionStatus transaction_status = 8;
+  // Index of the log in the transaction.
+  uint32 log_index_in_transaction = 9;
 }
 
 message Signature {

--- a/protocol/proto/starknet/v2/data.proto
+++ b/protocol/proto/starknet/v2/data.proto
@@ -257,6 +257,8 @@ message Event {
   FieldElement transaction_hash = 7;
   // Transaction status.
   TransactionStatus transaction_status = 8;
+  // Event index in the transaction.
+  uint32 event_index_in_transaction = 9;
 }
 
 message MessageToL1 {
@@ -275,6 +277,8 @@ message MessageToL1 {
   FieldElement transaction_hash = 7;
   // Transaction status.
   TransactionStatus transaction_status = 8;
+  // Message index in the transaction.
+  uint32 message_index_in_transaction = 9;
 }
 
 enum L1DataAvailabilityMode {

--- a/starknet/Cargo.toml
+++ b/starknet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.12"
+version = "2.0.0-beta.13"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/starknet/src/ingestion.rs
+++ b/starknet/src/ingestion.rs
@@ -414,13 +414,14 @@ fn collect_block_body_and_index(
         let mut transaction_events_id = Vec::new();
         let mut transaction_messages_id = Vec::new();
 
-        for event in events.iter() {
+        for (event_index_in_transaction, event) in events.iter().enumerate() {
             let mut event = event.to_proto();
 
             event.event_index = block_events.len() as u32;
             event.transaction_index = transaction_index;
             event.transaction_hash = transaction_hash.into();
             event.transaction_status = transaction_status as i32;
+            event.event_index_in_transaction = event_index_in_transaction as u32;
 
             join_transaction_to_events.insert(transaction_index, event.event_index);
             join_event_to_transaction.insert(event.event_index, transaction_index);
@@ -469,13 +470,14 @@ fn collect_block_body_and_index(
             models::TransactionReceipt::DeployAccount(rx) => &rx.messages_sent,
         };
 
-        for message in messages.iter() {
+        for (message_index_in_transaction, message) in messages.iter().enumerate() {
             let mut message = message.to_proto();
 
             message.message_index = block_messages.len() as u32;
             message.transaction_index = transaction_index;
             message.transaction_hash = transaction_hash.into();
             message.transaction_status = transaction_status as i32;
+            message.message_index_in_transaction = message_index_in_transaction as u32;
 
             join_transaction_to_messages.insert(transaction_index, message.message_index);
             join_message_to_transaction.insert(message.message_index, transaction_index);

--- a/starknet/src/proto.rs
+++ b/starknet/src/proto.rs
@@ -604,6 +604,7 @@ impl ModelExt for models::Event {
             transaction_index: u32::MAX,
             transaction_hash: None,
             transaction_status: 0,
+            event_index_in_transaction: u32::MAX,
         }
     }
 }
@@ -621,6 +622,7 @@ impl ModelExt for models::MsgToL1 {
             transaction_index: u32::MAX,
             transaction_hash: None,
             transaction_status: 0,
+            message_index_in_transaction: u32::MAX,
         }
     }
 }


### PR DESCRIPTION
### Summary

Fix issues with missing data caused by group compaction. This was caused by the compaction not considering that segments include data up to the end of the segment range.

Also add a transaction-local index to events, messages, and logs.
