### PR TITLE
Fix behaviour at chain's head

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.13"
+version = "2.0.0-beta.14"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.13"
+version = "2.0.0-beta.14"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.13"
+version = "2.0.0-beta.14"
 dependencies = [
  "apibara-dna-common",
  "apibara-dna-protocol",

--- a/beaconchain/Cargo.toml
+++ b/beaconchain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.13"
+version = "2.0.0-beta.14"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.13"
+version = "2.0.0-beta.14"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/starknet/Cargo.toml
+++ b/starknet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.13"
+version = "2.0.0-beta.14"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
### Summary

This PR fixes a couple of small things at the chain's head:

 - empty block (if requested) are sent only at the chain's tip.
 - heartbeats are sent when scan operations are taking too long.
