### PR TITLE
Improve beacon chain blob endpoint compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.14"
+version = "2.0.0-beta.15"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.14"
+version = "2.0.0-beta.15"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.14"
+version = "2.0.0-beta.15"
 dependencies = [
  "apibara-dna-common",
  "apibara-dna-protocol",

--- a/beaconchain/Cargo.toml
+++ b/beaconchain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.14"
+version = "2.0.0-beta.15"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/beaconchain/src/provider/models.rs
+++ b/beaconchain/src/provider/models.rs
@@ -99,7 +99,7 @@ pub struct Withdrawal {
     pub amount: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct BlobSidecarResponse {
     pub data: Vec<BlobSidecar>,
 }

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.14"
+version = "2.0.0-beta.15"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/starknet/Cargo.toml
+++ b/starknet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.14"
+version = "2.0.0-beta.15"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
### Summary

This PR improves compatibility with Beacon Chain RPCs by handling the case of pre-deneb blocks.
Some nodes (e.g. Erigon v3) return an empty list, while others return a 400 or 404 response.
