### PR TITLE
Speedup compaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.16"
+version = "2.0.0-beta.17"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.16"
+version = "2.0.0-beta.17"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.16"
+version = "2.0.0-beta.17"
 dependencies = [
  "apibara-dna-common",
  "apibara-dna-protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,6 +615,7 @@ dependencies = [
  "etcd-client",
  "foyer",
  "futures",
+ "futures-buffered",
  "futures-util",
  "hex",
  "memmap2",
@@ -1862,6 +1863,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "cordyceps"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec10f0a762d93c4498d2e97a333805cb6250d60bead623f71d8034f9a4152ba3"
+dependencies = [
+ "loom",
+ "tracing",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2145,6 +2156,12 @@ dependencies = [
  "quote",
  "syn 2.0.90",
 ]
+
+[[package]]
+name = "diatomic-waker"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab03c107fafeb3ee9f5925686dbb7a73bc76e3932abb0d2b365cb64b169cf04c"
 
 [[package]]
 name = "digest"
@@ -2732,6 +2749,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-buffered"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34acda8ae8b63fbe0b2195c998b180cff89a8212fb2622a78b572a9f1c6f7684"
+dependencies = [
+ "cordyceps",
+ "diatomic-waker",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2810,6 +2839,19 @@ name = "futures-utils-wasm"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
+
+[[package]]
+name = "generator"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
+]
 
 [[package]]
 name = "generic-array"
@@ -3638,6 +3680,19 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "loom"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "lru"
@@ -5248,6 +5303,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6758,6 +6819,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ fastrace = "0.7"
 fastrace-opentelemetry = "0.8"
 foyer = { version = "0.13.1", features = ["tracing"] }
 futures = "0.3.30"
+futures-buffered = "0.2.9"
 futures-util = "0.3.30"
 hex = { version = "0.4.3", features = ["serde"] }
 memmap2 = "0.9.4"

--- a/beaconchain/Cargo.toml
+++ b/beaconchain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.16"
+version = "2.0.0-beta.17"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -27,6 +27,7 @@ error-stack.workspace = true
 etcd-client.workspace = true
 foyer.workspace = true
 futures.workspace = true
+futures-buffered.workspace = true
 futures-util.workspace = true
 hex.workspace = true
 memmap2.workspace = true

--- a/common/src/block_store.rs
+++ b/common/src/block_store.rs
@@ -200,6 +200,14 @@ impl UncachedBlockStoreReader {
         self.get_segment(first_cursor, "index").await
     }
 
+    pub async fn get_index_segment_and_cursor(
+        &self,
+        first_cursor: Cursor,
+    ) -> Result<(Cursor, Bytes), BlockStoreError> {
+        let segment = self.get_segment(&first_cursor, "index").await?;
+        Ok((first_cursor, segment))
+    }
+
     #[tracing::instrument(name = "uncached_block_store_get_segment", skip_all, fields(name))]
     pub async fn get_segment(
         &self,

--- a/common/src/block_store.rs
+++ b/common/src/block_store.rs
@@ -179,6 +179,23 @@ impl UncachedBlockStoreReader {
         Ok(response.body)
     }
 
+    #[tracing::instrument(name = "uncached_block_store_get_block", skip_all)]
+    pub async fn get_block_and_cursor(
+        &self,
+        cursor: Cursor,
+    ) -> Result<(Cursor, Bytes), BlockStoreError> {
+        let key = format_block_key(&cursor);
+        let response = self
+            .client
+            .get(&key, GetOptions::default())
+            .await
+            .change_context(BlockStoreError)
+            .attach_printable("failed to get block")
+            .attach_printable_lazy(|| format!("cursor: {}", cursor))?;
+
+        Ok((cursor, response.body))
+    }
+
     pub async fn get_index_segment(&self, first_cursor: &Cursor) -> Result<Bytes, BlockStoreError> {
         self.get_segment(first_cursor, "index").await
     }

--- a/common/src/compaction/group_builder.rs
+++ b/common/src/compaction/group_builder.rs
@@ -14,7 +14,8 @@ use super::CompactionError;
 #[derive(Debug)]
 pub struct SegmentGroupBuilder {
     segment_size: u64,
-    block_range: Option<(Cursor, u64)>,
+    pub segment_count: usize,
+    pub block_range: Option<(Cursor, u64)>,
     block_indexes: BTreeMap<FragmentId, BTreeMap<IndexId, index::BitmapIndexBuilder>>,
 }
 
@@ -22,6 +23,7 @@ impl SegmentGroupBuilder {
     pub fn new(segment_size: usize) -> Self {
         Self {
             segment_size: segment_size as u64,
+            segment_count: 0,
             block_range: None,
             block_indexes: BTreeMap::new(),
         }
@@ -62,6 +64,8 @@ impl SegmentGroupBuilder {
                 }
             }
         }
+
+        self.segment_count += 1;
 
         Ok(())
     }

--- a/common/src/compaction/segment.rs
+++ b/common/src/compaction/segment.rs
@@ -212,6 +212,19 @@ impl SegmentService {
                     last_block_in_segment = block_cursor;
                 }
 
+                // Sanity checks
+                if builder.block_count() != self.segment_size {
+                    return Err(CompactionError)
+                        .attach_printable("builder block count does not match segment size")
+                        .attach_printable_lazy(|| {
+                            format!(
+                                "builder: {:}, segment: {:}",
+                                builder.block_count(),
+                                self.segment_size
+                            )
+                        });
+                }
+
                 let segment_data = builder.segment_data().change_context(CompactionError)?;
 
                 info!(

--- a/common/src/compaction/segment.rs
+++ b/common/src/compaction/segment.rs
@@ -1,7 +1,8 @@
 use error_stack::{Result, ResultExt};
-use futures::FutureExt;
+use futures::{FutureExt, StreamExt};
+use futures_buffered::FuturesOrderedBounded;
 use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::{debug, info};
 
 use crate::{
     block_store::{BlockStoreWriter, UncachedBlockStoreReader},
@@ -10,6 +11,8 @@ use crate::{
 };
 
 use super::{segment_builder::SegmentBuilder, CompactionError};
+
+const MAX_BUFFERED_BLOCKS: usize = 128;
 
 pub struct SegmentService {
     segment_size: usize,
@@ -91,27 +94,26 @@ impl SegmentService {
                     "creating new segment"
                 );
 
+                builder
+                    .start_new_segment(first_block_in_segment.clone())
+                    .change_context(CompactionError)?;
+
+                let buffered_queue_size = usize::min(self.segment_size, MAX_BUFFERED_BLOCKS);
+                let mut block_queue = FuturesOrderedBounded::new(buffered_queue_size);
+
                 let mut current = first_block_in_segment.clone();
                 let mut last_block_in_segment = first_block_in_segment.clone();
 
-                builder
-                    .start_new_segment(current.clone())
-                    .change_context(CompactionError)?;
+                debug!(
+                    first_block = %first_block_in_segment,
+                    buffered_queue_size,
+                    "starting segment compaction"
+                );
 
-                for _ in 0..self.segment_size {
-                    let entry = self
-                        .block_store_reader
-                        .get_block(&current)
-                        .await
-                        .change_context(CompactionError)
-                        .attach_printable("failed to get block")
-                        .attach_printable_lazy(|| format!("cursor: {current}"))?;
-
-                    builder
-                        .add_block(&current, &entry)
-                        .change_context(CompactionError)
-                        .attach_printable("failed to add block to segment")
-                        .attach_printable_lazy(|| format!("cursor: {current}"))?;
+                for _ in 0..buffered_queue_size {
+                    let block_cursor = current.clone();
+                    block_queue
+                        .push_back(self.block_store_reader.get_block_and_cursor(block_cursor));
 
                     let NextCursor::Continue {
                         cursor: next_cursor,
@@ -126,8 +128,88 @@ impl SegmentService {
                             .attach_printable_lazy(|| format!("cursor: {current}"));
                     };
 
-                    last_block_in_segment = current.clone();
+                    debug!(current = %current, "compaction: pushed block to queue");
+
                     current = next_cursor;
+                }
+
+                if self.segment_size > buffered_queue_size {
+                    debug!("compaction: queue full, waiting for blocks");
+
+                    for _ in buffered_queue_size..self.segment_size {
+                        let (block_cursor, block_data) = block_queue
+                            .next()
+                            .await
+                            .ok_or(CompactionError)
+                            .attach_printable("compaction segment buffer is empty")?
+                            .change_context(CompactionError)
+                            .attach_printable("failed to get block")?;
+
+                        builder
+                            .add_block(&block_cursor, &block_data)
+                            .change_context(CompactionError)
+                            .attach_printable("failed to add block to segment")
+                            .attach_printable_lazy(|| format!("cursor: {current}"))?;
+
+                        debug!(cursor = %block_cursor, "compaction: added block to segment");
+
+                        last_block_in_segment = block_cursor;
+
+                        let block_cursor = current.clone();
+                        block_queue
+                            .push_back(self.block_store_reader.get_block_and_cursor(block_cursor));
+
+                        let NextCursor::Continue {
+                            cursor: next_cursor,
+                            ..
+                        } = chain_view
+                            .get_next_cursor(&Some(current.clone()))
+                            .await
+                            .change_context(CompactionError)?
+                        else {
+                            return Err(CompactionError)
+                                .attach_printable("chain view returned invalid next cursor")
+                                .attach_printable_lazy(|| format!("cursor: {current}"));
+                        };
+
+                        debug!(current = %current, "compaction: pushed block to queue");
+
+                        current = next_cursor;
+                    }
+                }
+
+                debug!("compaction: pushed all blocks to queue");
+
+                for _ in 0..buffered_queue_size {
+                    let (block_cursor, block_data) = block_queue
+                        .next()
+                        .await
+                        .ok_or(CompactionError)
+                        .attach_printable("compaction segment buffer is empty")?
+                        .change_context(CompactionError)
+                        .attach_printable("failed to get block")?;
+
+                    builder
+                        .add_block(&block_cursor, &block_data)
+                        .change_context(CompactionError)
+                        .attach_printable("failed to add block to segment")
+                        .attach_printable_lazy(|| format!("cursor: {current}"))?;
+
+                    debug!(cursor = %block_cursor, "compaction: added block to segment");
+
+                    if block_cursor != first_block_in_segment
+                        && block_cursor.number != last_block_in_segment.number + 1
+                    {
+                        return Err(CompactionError)
+                            .attach_printable("block cursor number does not match expected number")
+                            .attach_printable_lazy(|| {
+                                format!(
+                                    "cursor: {block_cursor}, last_block: {last_block_in_segment}"
+                                )
+                            });
+                    }
+
+                    last_block_in_segment = block_cursor;
                 }
 
                 let segment_data = builder.segment_data().change_context(CompactionError)?;

--- a/common/src/compaction/segment_builder.rs
+++ b/common/src/compaction/segment_builder.rs
@@ -36,6 +36,10 @@ impl SegmentBuilder {
         Ok(())
     }
 
+    pub fn block_count(&self) -> usize {
+        self.headers.len()
+    }
+
     pub fn add_block(&mut self, cursor: &Cursor, bytes: &Bytes) -> Result<(), CompactionError> {
         let block = rkyv::from_bytes::<Block, rkyv::rancor::Error>(bytes)
             .change_context(CompactionError)

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.16"
+version = "2.0.0-beta.17"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/starknet/Cargo.toml
+++ b/starknet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.16"
+version = "2.0.0-beta.17"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
### Summary

This PR speeds up compaction 10x to 100x by fetching blocks/segments in parallel.

It uses a `FuturesOrderedBounded` queue to limit the number of concurrent fetches to a reasonable number (128) even with a larger segment size.
