### PR TITLE
Minor data stream fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.18"
+version = "2.0.0-beta.19"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.18"
+version = "2.0.0-beta.19"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.18"
+version = "2.0.0-beta.19"
 dependencies = [
  "apibara-dna-common",
  "apibara-dna-protocol",

--- a/beaconchain/Cargo.toml
+++ b/beaconchain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.18"
+version = "2.0.0-beta.19"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/common/src/data_stream/metrics.rs
+++ b/common/src/data_stream/metrics.rs
@@ -5,6 +5,7 @@ pub struct DataStreamMetrics {
     pub active: UpDownCounter<i64>,
     pub block_size: Histogram<u64>,
     pub fragment_size: Histogram<u64>,
+    pub time_in_queue: Histogram<f64>,
     pub block: RequestMetrics,
     pub segment: RequestMetrics,
     pub group: RequestMetrics,
@@ -52,6 +53,15 @@ impl Default for DataStreamMetrics {
                     50_000_000.0,
                     100_000_000.0,
                     1_000_000_000.0,
+                ])
+                .build(),
+            time_in_queue: meter
+                .f64_histogram("dna.data_stream.time_in_queue")
+                .with_description("time (in seconds) spent in the prefetch queue")
+                .with_unit("s")
+                .with_boundaries(vec![
+                    0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.0075, 0.01, 0.025, 0.05,
+                    0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0,
                 ])
                 .build(),
             block: RequestMetrics::new_with_boundaries(

--- a/common/src/data_stream/metrics.rs
+++ b/common/src/data_stream/metrics.rs
@@ -1,0 +1,83 @@
+use apibara_observability::{Histogram, RequestMetrics, UpDownCounter};
+
+#[derive(Debug, Clone)]
+pub struct DataStreamMetrics {
+    pub active: UpDownCounter<i64>,
+    pub block_size: Histogram<u64>,
+    pub fragment_size: Histogram<u64>,
+    pub block: RequestMetrics,
+    pub segment: RequestMetrics,
+    pub group: RequestMetrics,
+}
+
+impl Default for DataStreamMetrics {
+    fn default() -> Self {
+        let meter = apibara_observability::meter("dna_data_stream");
+
+        Self {
+            active: meter
+                .i64_up_down_counter("dna.data_stream.active")
+                .with_description("number of active data streams")
+                .with_unit("{connection}")
+                .build(),
+            block_size: meter
+                .u64_histogram("dna.data_stream.block_size")
+                .with_description("size (in bytes) of blocks sent to the client")
+                .with_unit("By")
+                .with_boundaries(vec![
+                    1_000.0,
+                    10_000.0,
+                    100_000.0,
+                    1_000_000.0,
+                    5_000_000.0,
+                    10_000_000.0,
+                    25_000_000.0,
+                    50_000_000.0,
+                    100_000_000.0,
+                    1_000_000_000.0,
+                ])
+                .build(),
+            fragment_size: meter
+                .u64_histogram("dna.data_stream.fragment_size")
+                .with_description("size (in bytes) of fragments sent to the client")
+                .with_unit("By")
+                .with_boundaries(vec![
+                    1_000.0,
+                    10_000.0,
+                    100_000.0,
+                    1_000_000.0,
+                    5_000_000.0,
+                    10_000_000.0,
+                    25_000_000.0,
+                    50_000_000.0,
+                    100_000_000.0,
+                    1_000_000_000.0,
+                ])
+                .build(),
+            block: RequestMetrics::new_with_boundaries(
+                "dna_data_stream",
+                "dna.data_stream.block",
+                vec![
+                    0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.0075, 0.01, 0.025, 0.05,
+                    0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0,
+                ],
+            ),
+            segment: RequestMetrics::new_with_boundaries(
+                "dna_data_stream",
+                "dna.data_stream.segment",
+                vec![
+                    0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.0075, 0.01, 0.025, 0.05,
+                    0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0,
+                ],
+            ),
+            group: RequestMetrics::new_with_boundaries(
+                "dna_data_stream",
+                "dna.data_stream.group",
+                vec![
+                    0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.0075, 0.01, 0.025, 0.05,
+                    0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0,
+                ],
+            ),
+        }
+    }
+}

--- a/common/src/data_stream/mod.rs
+++ b/common/src/data_stream/mod.rs
@@ -1,5 +1,6 @@
 mod filter;
 mod fragment_access;
+mod metrics;
 mod segment_access;
 mod segment_stream;
 mod stream;
@@ -7,6 +8,7 @@ mod stream_group;
 
 pub use self::filter::{BlockFilterFactory, FilterMatch};
 pub use self::fragment_access::FragmentAccess;
+pub use self::metrics::DataStreamMetrics;
 pub use self::segment_access::{SegmentAccess, SegmentAccessFetch};
 pub use self::segment_stream::SegmentStream;
-pub use self::stream::{DataStream, DataStreamError, DataStreamMetrics};
+pub use self::stream::{DataStream, DataStreamError};

--- a/common/src/data_stream/stream.rs
+++ b/common/src/data_stream/stream.rs
@@ -225,6 +225,7 @@ impl DataStream {
                         debug!("tick: segment stream consumer finished");
                         return Ok(());
                     };
+
                     let segment_access = segment_fetch.wait()
                         .record_request(self.metrics.segment.clone())
                         .await.change_context(DataStreamError)
@@ -234,6 +235,9 @@ impl DataStream {
 
                     for block_access in segment_access.iter() {
                         let block_end_cursor = block_access.cursor();
+                        if block_end_cursor.number < cursor.number {
+                            continue;
+                        }
 
                         let proto_cursor = None;
                         let proto_end_cursor: Option<ProtoCursor> = Some(block_end_cursor.clone().into());

--- a/common/src/dbg/prefetch.rs
+++ b/common/src/dbg/prefetch.rs
@@ -10,7 +10,7 @@ use crate::{
     block_store::BlockStoreReader,
     chain_view::chain_view_sync_loop,
     cli::{EtcdArgs, ObjectStoreArgs},
-    data_stream::{SegmentAccessFetch, SegmentStream},
+    data_stream::{DataStreamMetrics, SegmentAccessFetch, SegmentStream},
     file_cache::FileCacheArgs,
     fragment::FragmentId,
     query::BlockFilter,
@@ -67,8 +67,13 @@ pub async fn run_debug_prefetch_stream(
         .await
         .change_context(DebugCommandError)?;
 
-    let segment_stream =
-        SegmentStream::new(vec![filter], fragment_id_to_name, block_store, chain_view);
+    let segment_stream = SegmentStream::new(
+        vec![filter],
+        fragment_id_to_name,
+        block_store,
+        chain_view,
+        DataStreamMetrics::default(),
+    );
 
     let (tx, rx) = mpsc::channel(queue_size);
 

--- a/common/src/server/cli.rs
+++ b/common/src/server/cli.rs
@@ -25,7 +25,14 @@ pub struct ServerArgs {
         env = "DNA_SERVER_MAX_CONCURRENT_STREAMS",
         default_value = "1000"
     )]
-    pub max_concurrent_streams: usize,
+    pub server_max_concurrent_streams: usize,
+    /// Number of prefetch segments.
+    #[clap(
+        long = "server.prefetch-segment-count",
+        env = "DNA_SERVER_PREFETCH_SEGMENT_COUNT",
+        default_value = "128"
+    )]
+    pub server_prefetch_segment_count: usize,
 }
 
 impl ServerArgs {
@@ -38,7 +45,8 @@ impl ServerArgs {
             .attach_printable_lazy(|| format!("address: {}", self.server_address))?;
 
         let stream_service_options = StreamServiceOptions {
-            max_concurrent_streams: self.max_concurrent_streams,
+            max_concurrent_streams: self.server_max_concurrent_streams,
+            prefetch_segment_count: self.server_prefetch_segment_count,
         };
 
         Ok(ServerOptions {

--- a/common/src/server/service.rs
+++ b/common/src/server/service.rs
@@ -27,6 +27,8 @@ static STREAM_SEMAPHORE_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(1);
 pub struct StreamServiceOptions {
     /// Maximum number of concurrent streams.
     pub max_concurrent_streams: usize,
+    /// Number of segments to prefetch.
+    pub prefetch_segment_count: usize,
 }
 
 pub struct StreamService<BFF>
@@ -201,6 +203,7 @@ where
             chain_view,
             self.fragment_id_to_name.clone(),
             self.block_store.clone(),
+            self.options.prefetch_segment_count,
             permit,
             self.metrics.clone(),
         );

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.18"
+version = "2.0.0-beta.19"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,12 @@
               "7007/tcp" = { };
             };
           };
+
+          benchmark = {
+            description = "Apibara benchmark";
+            path = ./benchmark;
+            ports = { };
+          };
         };
 
         builtCrates = pkgs.callPackage ./nix/crates.nix {

--- a/starknet/Cargo.toml
+++ b/starknet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.18"
+version = "2.0.0-beta.19"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
### Summary

This PR fixes a bug in the data stream that resulted in blocks before the specified starting cursor to be sent.

We also add missing data stream metrics and make the prefetch queue size configurable.
