### PR TITLE
Minor performance improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.19"
+version = "2.0.0-beta.20"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.19"
+version = "2.0.0-beta.20"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.19"
+version = "2.0.0-beta.20"
 dependencies = [
  "apibara-dna-common",
  "apibara-dna-protocol",

--- a/beaconchain/Cargo.toml
+++ b/beaconchain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.19"
+version = "2.0.0-beta.20"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/common/src/data_stream/stream.rs
+++ b/common/src/data_stream/stream.rs
@@ -278,7 +278,7 @@ impl DataStream {
     ) -> Result<(), DataStreamError> {
         use apibara_dna_protocol::dna::stream::Cursor as ProtoCursor;
 
-        debug!(cursor = %cursor, "tick: single block");
+        debug!(cursor = %cursor, is_head, "tick: single block");
 
         let proto_cursor: Option<ProtoCursor> = self.current.clone().map(Into::into);
         let proto_end_cursor: Option<ProtoCursor> = Some(cursor.clone().into());

--- a/common/src/file_cache.rs
+++ b/common/src/file_cache.rs
@@ -75,7 +75,7 @@ pub struct FileCacheArgs {
     #[clap(
         long = "cache.compression",
         env = "DNA_CACHE_COMPRESSION",
-        default_value = "none"
+        default_value = "zstd"
     )]
     pub cache_compression: String,
     /// Enable `sync` after writes.

--- a/common/src/file_cache.rs
+++ b/common/src/file_cache.rs
@@ -7,7 +7,7 @@ use error_stack::{Result, ResultExt};
 use foyer::{
     AdmissionPicker, AdmitAllPicker, CacheEntry, Compression, DirectFsDeviceOptions, Engine,
     HybridCache, HybridCacheBuilder, HybridFetch, LargeEngineOptions, RateLimitPicker, RecoverMode,
-    RuntimeOptions, TokioRuntimeOptions,
+    RuntimeOptions, S3FifoConfig, TokioRuntimeOptions,
 };
 
 #[derive(Debug)]
@@ -166,6 +166,7 @@ impl FileCacheArgs {
             .with_name("global")
             .with_metrics_registry(mixtrics_registry("file_cache"))
             .memory(max_size_memory_bytes as usize)
+            .with_eviction_config(S3FifoConfig::default())
             .with_weighter(|_: &String, bytes: &Bytes| bytes.len())
             .storage(Engine::Large)
             .with_compression(compression)
@@ -194,8 +195,6 @@ impl FileCacheArgs {
             .with_recover_mode(RecoverMode::Quiet);
 
         let cache = builder.build().await.map_err(FileCacheError::Foyer)?;
-
-        cache.enable_tracing();
 
         Ok(cache)
     }

--- a/common/src/query.rs
+++ b/common/src/query.rs
@@ -143,6 +143,6 @@ impl std::fmt::Display for FilterError {
 
 impl Default for HeaderFilter {
     fn default() -> Self {
-        Self::OnData
+        Self::OnDataOrOnNewBlock
     }
 }

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.19"
+version = "2.0.0-beta.20"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/observability/src/lib.rs
+++ b/observability/src/lib.rs
@@ -144,9 +144,9 @@ where
     // export traces and metrics to otel
     let otel_trace_layer = tracing_opentelemetry::layer().with_tracer(tracer);
     let otel_metrics_layer = MetricsLayer::new(meter_provider);
-    let otel_layer = otel_trace_layer
+    let otel_layer = otel_env_filter
         .and_then(otel_metrics_layer)
-        .and_then(otel_env_filter)
+        .and_then(otel_trace_layer)
         .boxed();
 
     Ok(otel_layer)

--- a/starknet/Cargo.toml
+++ b/starknet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.19"
+version = "2.0.0-beta.20"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
### Summary

This PR includes some small changes that result in increased performance.

 - Prefetch segment groups while streaming. This was previously the bottleneck.
 - Enable cache compression to store more groups/segments/blocks on disk.
 - Use S3 Fifo cache admission.

We also change the default filter behaviour to always send the tip of the chain.

