### PR TITLE
Improve segment stream metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.20"
+version = "2.0.0-beta.21"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.20"
+version = "2.0.0-beta.21"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.20"
+version = "2.0.0-beta.21"
 dependencies = [
  "apibara-dna-common",
  "apibara-dna-protocol",

--- a/beaconchain/Cargo.toml
+++ b/beaconchain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.20"
+version = "2.0.0-beta.21"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/common/src/block_store.rs
+++ b/common/src/block_store.rs
@@ -81,7 +81,7 @@ impl BlockStoreReader {
                 }
             }
         };
-        let entry = self.file_cache.fetch(key, fetch_block);
+        let entry = self.file_cache.general.fetch(key, fetch_block);
 
         match entry.state() {
             FetchState::Miss => current_span.record("cache_hit", 0),
@@ -113,7 +113,7 @@ impl BlockStoreReader {
                 }
             }
         };
-        let entry = self.file_cache.fetch(key, fetch_block);
+        let entry = self.file_cache.general.fetch(key, fetch_block);
 
         match entry.state() {
             FetchState::Miss => current_span.record("cache_hit", 0),
@@ -154,7 +154,7 @@ impl BlockStoreReader {
             }
         };
 
-        let entry = self.file_cache.fetch(key, fetch_segment);
+        let entry = self.file_cache.general.fetch(key, fetch_segment);
 
         match entry.state() {
             FetchState::Miss => current_span.record("cache_hit", 0),
@@ -188,7 +188,7 @@ impl BlockStoreReader {
                 }
             }
         };
-        let entry = self.file_cache.fetch(key, fetch_group);
+        let entry = self.file_cache.general.fetch(key, fetch_group);
 
         match entry.state() {
             FetchState::Miss => current_span.record("cache_hit", 0),

--- a/common/src/chain_store.rs
+++ b/common/src/chain_store.rs
@@ -99,6 +99,7 @@ impl ChainStore {
 
         if let Some(existing) = self
             .cache
+            .general
             .get(&key)
             .await
             .map_err(FileCacheError::Foyer)
@@ -115,7 +116,7 @@ impl ChainStore {
                 return Ok(None);
             };
 
-            let entry = self.cache.insert(key, bytes);
+            let entry = self.cache.general.insert(key, bytes);
 
             let segment = rkyv::from_bytes::<_, rkyv::rancor::Error>(entry.value())
                 .change_context(ChainStoreError)

--- a/common/src/data_stream/metrics.rs
+++ b/common/src/data_stream/metrics.rs
@@ -1,4 +1,4 @@
-use apibara_observability::{Histogram, RequestMetrics, UpDownCounter};
+use apibara_observability::{Counter, Histogram, RequestMetrics, UpDownCounter};
 
 #[derive(Debug, Clone)]
 pub struct DataStreamMetrics {
@@ -6,9 +6,12 @@ pub struct DataStreamMetrics {
     pub block_size: Histogram<u64>,
     pub fragment_size: Histogram<u64>,
     pub time_in_queue: Histogram<f64>,
-    pub block: RequestMetrics,
-    pub segment: RequestMetrics,
-    pub group: RequestMetrics,
+    pub block_download: RequestMetrics,
+    pub segment_download: RequestMetrics,
+    pub segment_wait: RequestMetrics,
+    pub group_download: RequestMetrics,
+    pub group_wait: RequestMetrics,
+    pub group_cache_hit: Counter<u64>,
 }
 
 impl Default for DataStreamMetrics {
@@ -64,30 +67,50 @@ impl Default for DataStreamMetrics {
                     0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0,
                 ])
                 .build(),
-            block: RequestMetrics::new_with_boundaries(
+            block_download: RequestMetrics::new_with_boundaries(
                 "dna_data_stream",
-                "dna.data_stream.block",
+                "dna.data_stream.block_download",
                 vec![
                     0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.0075, 0.01, 0.025, 0.05,
                     0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0,
                 ],
             ),
-            segment: RequestMetrics::new_with_boundaries(
+            segment_download: RequestMetrics::new_with_boundaries(
                 "dna_data_stream",
-                "dna.data_stream.segment",
+                "dna.data_stream.segment_download",
                 vec![
                     0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.0075, 0.01, 0.025, 0.05,
                     0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0,
                 ],
             ),
-            group: RequestMetrics::new_with_boundaries(
+            segment_wait: RequestMetrics::new_with_boundaries(
                 "dna_data_stream",
-                "dna.data_stream.group",
+                "dna.data_stream.segment_wait",
                 vec![
                     0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.0075, 0.01, 0.025, 0.05,
                     0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0,
                 ],
             ),
+            group_download: RequestMetrics::new_with_boundaries(
+                "dna_data_stream",
+                "dna.data_stream.group_download",
+                vec![
+                    0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.0075, 0.01, 0.025, 0.05,
+                    0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0,
+                ],
+            ),
+            group_wait: RequestMetrics::new_with_boundaries(
+                "dna_data_stream",
+                "dna.data_stream.group_wait",
+                vec![
+                    0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.0075, 0.01, 0.025, 0.05,
+                    0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0,
+                ],
+            ),
+            group_cache_hit: meter
+                .u64_counter("dna.data_stream.group_cache_hit")
+                .with_description("number of group cache hits")
+                .build(),
         }
     }
 }

--- a/common/src/data_stream/segment_access.rs
+++ b/common/src/data_stream/segment_access.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, time::Instant};
 
+use apibara_observability::RecordedRequest;
 use bytes::Bytes;
 use error_stack::{Result, ResultExt};
 use foyer::CacheEntry;
@@ -22,7 +23,7 @@ pub type FileEntry = CacheEntry<String, Bytes>;
 pub struct SegmentAccessFetch {
     first_block: u64,
     blocks: RoaringBitmap,
-    fragments: HashMap<FragmentId, FileFetch>,
+    fragments: HashMap<FragmentId, RecordedRequest<FileFetch>>,
     created_at: Instant,
 }
 
@@ -52,7 +53,7 @@ impl SegmentAccessFetch {
         }
     }
 
-    pub fn insert_fragment(&mut self, fragment_id: FragmentId, fetch: FileFetch) {
+    pub fn insert_fragment(&mut self, fragment_id: FragmentId, fetch: RecordedRequest<FileFetch>) {
         self.fragments.insert(fragment_id, fetch);
     }
 

--- a/common/src/data_stream/stream.rs
+++ b/common/src/data_stream/stream.rs
@@ -224,7 +224,7 @@ impl DataStream {
                     };
 
                     let segment_access = segment_fetch.wait(&self.metrics)
-                        .record_request(self.metrics.segment.clone())
+                        .record_request(self.metrics.segment_wait.clone())
                         .await.change_context(DataStreamError)
                             .attach_printable("Failed to wait for segment fetch")?;
 
@@ -298,7 +298,7 @@ impl DataStream {
         let block_entry: BlockAccess = self
             .store
             .get_block(&cursor)
-            .record_request(self.metrics.block.clone())
+            .record_request(self.metrics.block_download.clone())
             .await
             .map_err(FileCacheError::Foyer)
             .change_context(DataStreamError)

--- a/common/tests/test_ingestion_service.rs
+++ b/common/tests/test_ingestion_service.rs
@@ -58,12 +58,13 @@ async fn init_anvil() -> (ContainerAsync<AnvilServer>, Arc<AnvilProvider>) {
 }
 
 async fn init_file_cache() -> FileCache {
-    HybridCacheBuilder::default()
+    let general = HybridCacheBuilder::default()
         .memory(1024 * 1024)
         .storage(foyer::Engine::Large)
         .build()
         .await
-        .expect("failed to create file cache")
+        .expect("failed to create file cache");
+    FileCache { general }
 }
 
 #[tokio::test]

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.20"
+version = "2.0.0-beta.21"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/starknet/Cargo.toml
+++ b/starknet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.20"
+version = "2.0.0-beta.21"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
### Summary

This PR is in preparation of the upcoming changes to the file cache. We record better metrics so that we can then measure the impact of our changes.

 - Record segment and group download and wait times.
 - Record group cache hit.
