### PR TITLE
Fix docker image size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,7 +538,7 @@ checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
 name = "apibara-benchmark"
-version = "0.0.0"
+version = "2.0.0"
 dependencies = [
  "apibara-dna-common",
  "apibara-dna-protocol",

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-benchmark"
-version = "0.0.0"
+version = "2.0.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1734324364,
-        "narHash": "sha256-omYTR59TdH0AumP1cfh49fBnWZ52HjfdNfaLzCMZBx0=",
+        "lastModified": 1739638817,
+        "narHash": "sha256-pPiI27T416xAAUETorkLAgHQMiLT92moOrf0ItHhtPA=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "60d7623f1320470bf2fdb92fd2dca1e9a27b98ce",
+        "rev": "bef2b45cd1273a9e621fb5292de89f4ed59ad812",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734119587,
-        "narHash": "sha256-AKU6qqskl0yf2+JdRdD0cfxX4b9x3KKV5RqA6wijmPM=",
+        "lastModified": 1739580444,
+        "narHash": "sha256-+/bSz4EAVbqz8/HsIGLroF8aNaO8bLRL7WfACN+24g4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
+        "rev": "8bb37161a0488b89830168b81c48aed11569cb93",
         "type": "github"
       },
       "original": {
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734316514,
-        "narHash": "sha256-0aLx44yMblcOGpfFXKCzp2GhU5JaE6OTvdU+JYrXiUc=",
+        "lastModified": 1739759407,
+        "narHash": "sha256-YIrVxD2SaUyaEdMry2nAd2qG1E0V38QIV6t6rpguFwk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "83ee8ff74d6294a7657320f16814754c4594127b",
+        "rev": "6e6ae2acf4221380140c22d65b6c41f4726f5932",
         "type": "github"
       },
       "original": {

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -211,7 +211,9 @@ let
           caCertificates
         ];
         config = {
-          Entrypoint = [ ];
+          Entrypoint = [
+            "${crate.out}/bin/apibara-${name}"
+          ];
           ExposedPorts = crate.meta.ports;
           Labels = ({
             "org.opencontainers.image.source" = "https://github.com/apibara/dna";

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.83"
+channel = "1.84"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
### Summary

This PR updates crane to fix the issue with docker image sizes.
We also update the Rust toolchain to 1.84.
