### PR TITLE
Support transaction traces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-client",
  "alloy-rpc-types-eth",
+ "alloy-rpc-types-trace",
  "alloy-transport",
  "alloy-transport-http",
  "async-stream",
@@ -353,6 +354,20 @@ dependencies = [
  "itertools 0.13.0",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "alloy-rpc-types-trace"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98db35cd42c90b484377e6bc44d95377a7a38a5ebee996e67754ac0446d542ab"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -660,6 +675,7 @@ dependencies = [
  "alloy-provider",
  "alloy-rpc-client",
  "alloy-rpc-types",
+ "alloy-rpc-types-trace",
  "alloy-transport",
  "apibara-dna-common",
  "apibara-dna-protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.25"
+version = "2.0.0-beta.26"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -669,7 +669,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.25"
+version = "2.0.0-beta.26"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.25"
+version = "2.0.0-beta.26"
 dependencies = [
  "apibara-dna-common",
  "apibara-dna-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,9 @@ incremental = false
 alloy-primitives = "0.8"
 alloy-eips = "0.3.6"
 alloy-rpc-client = "0.3.6"
-alloy-provider = "0.3.6"
+alloy-provider = { version = "0.3.6", features = ["trace-api"] }
 alloy-rpc-types = "0.3.6"
+alloy-rpc-types-trace = "0.3.6"
 alloy-transport = "0.3.6"
 alloy-transport-http = "0.3.6"
 bytes = { version = "1.7.1", features = ["serde"] }

--- a/beaconchain/Cargo.toml
+++ b/beaconchain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.25"
+version = "2.0.0-beta.26"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/common/src/block_store.rs
+++ b/common/src/block_store.rs
@@ -1,4 +1,4 @@
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use apibara_observability::{Counter, KeyValue};
 use bytes::Bytes;
 use error_stack::{Result, ResultExt};
@@ -81,7 +81,7 @@ impl BlockStoreReader {
                 async move {
                     match client.get(&key, GetOptions::default()).await {
                         Ok(response) => Ok(response.body),
-                        Err(err) => Err(anyhow!(err)),
+                        Err(err) => Err(anyhow!(err)).with_context(|| format!("block key: {key}")),
                     }
                 }
             }
@@ -118,7 +118,9 @@ impl BlockStoreReader {
                 async move {
                     match client.get(&key, GetOptions::default()).await {
                         Ok(response) => Ok(response.body),
-                        Err(err) => Err(anyhow!(err)),
+                        Err(err) => {
+                            Err(anyhow!(err)).with_context(|| format!("pending block key: {key}"))
+                        }
                     }
                 }
             }
@@ -163,7 +165,9 @@ impl BlockStoreReader {
                 async move {
                     match client.get(&key, GetOptions::default()).await {
                         Ok(response) => Ok(response.body),
-                        Err(err) => Err(anyhow!(err)),
+                        Err(err) => {
+                            Err(anyhow!(err)).with_context(|| format!("segment key: {key}"))
+                        }
                     }
                 }
             }
@@ -203,7 +207,7 @@ impl BlockStoreReader {
                 async move {
                     match client.get(&key, GetOptions::default()).await {
                         Ok(response) => Ok(response.body),
-                        Err(err) => Err(anyhow!(err)),
+                        Err(err) => Err(anyhow!(err)).with_context(|| format!("group key: {key}")),
                     }
                 }
             }

--- a/common/src/chain_view/full.rs
+++ b/common/src/chain_view/full.rs
@@ -168,7 +168,9 @@ impl FullCanonicalChain {
             .change_context(ChainViewError)
             .attach_printable("failed to get chain segment")?
             .ok_or(ChainViewError)
-            .attach_printable("chain segment not found")?;
+            .attach_printable("chain segment not found")
+            .attach_printable_lazy(|| format!("block number: {}", block_number))
+            .attach_printable_lazy(|| format!("starting block: {}", chain_segment_start))?;
 
         Ok(segment)
     }

--- a/common/src/data_stream/segment_access.rs
+++ b/common/src/data_stream/segment_access.rs
@@ -73,7 +73,8 @@ impl SegmentAccessFetch {
             let file = fetch
                 .await
                 .map_err(FileCacheError::Foyer)
-                .change_context(FragmentAccessError)?;
+                .change_context(FragmentAccessError)
+                .attach_printable_lazy(|| format!("fragment id: {fragment_id}"))?;
             access.fragments.insert(fragment_id, file);
         }
 

--- a/common/src/data_stream/stream.rs
+++ b/common/src/data_stream/stream.rs
@@ -474,9 +474,9 @@ impl DataStream {
         Ok(())
     }
 
-    async fn filter_fragment<'a>(
+    async fn filter_fragment(
         &self,
-        fragment_access: FragmentAccess<'a>,
+        fragment_access: FragmentAccess<'_>,
         _finality: &DataFinality,
         is_live: bool,
         output: &mut Vec<Bytes>,

--- a/common/src/ingestion/service.rs
+++ b/common/src/ingestion/service.rs
@@ -230,6 +230,7 @@ where
         fields(head, finalized, starting_block)
     )]
     pub async fn initialize(&mut self) -> Result<IngestionState, IngestionError> {
+        debug!("initializing ingestion");
         let head = self.ingestion.get_head_cursor().await?;
         let finalized = self.ingestion.get_finalized_cursor().await?;
 
@@ -237,6 +238,7 @@ where
 
         current_span.record("head", head.number);
         current_span.record("finalized", finalized.number);
+        debug!(head = %head, finalized = %finalized, "received head and finalized blocks");
 
         self.state_client
             .put_finalized(finalized.number)

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.25"
+version = "2.0.0-beta.26"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -19,6 +19,7 @@ alloy-rpc-client.workspace = true
 alloy-provider.workspace = true
 alloy-primitives.workspace = true
 alloy-rpc-types.workspace = true
+alloy-rpc-types-trace.workspace = true
 alloy-transport.workspace = true
 apibara-observability = { path = "../observability" }
 apibara-dna-common = { path = "../common" }

--- a/evm/src/cli/start.rs
+++ b/evm/src/cli/start.rs
@@ -22,6 +22,14 @@ pub struct StartCommand {
         default_value = "false"
     )]
     no_ingest_pending: bool,
+
+    /// Ingest transaction traces.
+    #[arg(
+        long = "evm.ingest-traces",
+        env = "EVM_INGEST_TRACES",
+        default_value = "false"
+    )]
+    ingest_traces: bool,
 }
 
 impl StartCommand {
@@ -30,6 +38,7 @@ impl StartCommand {
         let provider = self.rpc.to_json_rpc_provider()?;
         let evm_ingestion_options = EvmBlockIngestionOptions {
             ingest_pending: !self.no_ingest_pending,
+            ingest_traces: self.ingest_traces,
         };
         let evm_chain = EvmChainSupport::new(provider, evm_ingestion_options);
 

--- a/evm/src/filter/log.rs
+++ b/evm/src/filter/log.rs
@@ -7,7 +7,7 @@ use apibara_dna_protocol::evm;
 use crate::fragment::{
     INDEX_LOG_BY_ADDRESS, INDEX_LOG_BY_TOPIC0, INDEX_LOG_BY_TOPIC1, INDEX_LOG_BY_TOPIC2,
     INDEX_LOG_BY_TOPIC3, INDEX_LOG_BY_TOPIC_LENGTH, INDEX_LOG_BY_TRANSACTION_STATUS,
-    LOG_FRAGMENT_ID, RECEIPT_FRAGMENT_ID, TRANSACTION_FRAGMENT_ID,
+    LOG_FRAGMENT_ID, RECEIPT_FRAGMENT_ID, TRACE_FRAGMENT_ID, TRANSACTION_FRAGMENT_ID,
 };
 
 use super::helpers::FragmentFilterExt;
@@ -97,6 +97,10 @@ impl FragmentFilterExt for evm::LogFilter {
 
         if let Some(true) = self.include_siblings {
             joins.push(LOG_FRAGMENT_ID);
+        }
+
+        if let Some(true) = self.include_transaction_trace {
+            joins.push(TRACE_FRAGMENT_ID);
         }
 
         Ok(Filter {

--- a/evm/src/filter/transaction.rs
+++ b/evm/src/filter/transaction.rs
@@ -6,7 +6,8 @@ use apibara_dna_protocol::evm;
 
 use crate::fragment::{
     INDEX_TRANSACTION_BY_CREATE, INDEX_TRANSACTION_BY_FROM_ADDRESS, INDEX_TRANSACTION_BY_STATUS,
-    INDEX_TRANSACTION_BY_TO_ADDRESS, LOG_FRAGMENT_ID, RECEIPT_FRAGMENT_ID, TRANSACTION_FRAGMENT_ID,
+    INDEX_TRANSACTION_BY_TO_ADDRESS, LOG_FRAGMENT_ID, RECEIPT_FRAGMENT_ID, TRACE_FRAGMENT_ID,
+    TRANSACTION_FRAGMENT_ID,
 };
 
 use super::helpers::FragmentFilterExt;
@@ -72,6 +73,10 @@ impl FragmentFilterExt for evm::TransactionFilter {
 
         if let Some(true) = self.include_logs {
             joins.push(LOG_FRAGMENT_ID);
+        }
+
+        if let Some(true) = self.include_transaction_trace {
+            joins.push(TRACE_FRAGMENT_ID);
         }
 
         Ok(Filter {

--- a/evm/src/fragment.rs
+++ b/evm/src/fragment.rs
@@ -14,6 +14,9 @@ pub const RECEIPT_FRAGMENT_NAME: &str = "receipt";
 pub const LOG_FRAGMENT_ID: u8 = 5;
 pub const LOG_FRAGMENT_NAME: &str = "log";
 
+pub const TRACE_FRAGMENT_ID: u8 = 6;
+pub const TRACE_FRAGMENT_NAME: &str = "trace";
+
 pub const INDEX_WITHDRAWAL_BY_VALIDATOR_INDEX: u8 = 0;
 pub const INDEX_WITHDRAWAL_BY_ADDRESS: u8 = 1;
 

--- a/evm/src/lib.rs
+++ b/evm/src/lib.rs
@@ -7,6 +7,7 @@ pub mod proto;
 pub mod provider;
 
 use apibara_dna_common::{fragment::FragmentInfo, ChainSupport};
+use fragment::{TRACE_FRAGMENT_ID, TRACE_FRAGMENT_NAME};
 
 use crate::{
     filter::EvmFilterFactory,
@@ -53,6 +54,10 @@ impl ChainSupport for EvmChainSupport {
             FragmentInfo {
                 fragment_id: LOG_FRAGMENT_ID,
                 name: LOG_FRAGMENT_NAME.to_string(),
+            },
+            FragmentInfo {
+                fragment_id: TRACE_FRAGMENT_ID,
+                name: TRACE_FRAGMENT_NAME.to_string(),
             },
         ]
     }

--- a/evm/src/proto.rs
+++ b/evm/src/proto.rs
@@ -165,6 +165,167 @@ impl ModelExt for models::AccessListItem {
     }
 }
 
+impl ModelExt for models::TraceResults {
+    type Proto = evm::TransactionTrace;
+
+    fn to_proto(&self) -> Self::Proto {
+        evm::TransactionTrace {
+            filter_ids: Vec::default(),
+            transaction_index: u32::MAX,
+            transaction_hash: None,
+            traces: self.trace.iter().map(ModelExt::to_proto).collect(),
+        }
+    }
+}
+
+impl ModelExt for models::TransactionTrace {
+    type Proto = evm::Trace;
+
+    fn to_proto(&self) -> Self::Proto {
+        evm::Trace {
+            action: self.action.to_proto().into(),
+            error: self.error.clone(),
+            output: self.result.as_ref().map(ModelExt::to_proto),
+            subtraces: self.subtraces as u32,
+            trace_address: self.trace_address.iter().map(|a| *a as u32).collect(),
+        }
+    }
+}
+
+impl ModelExt for models::Action {
+    type Proto = evm::trace::Action;
+
+    fn to_proto(&self) -> Self::Proto {
+        use models::Action::*;
+
+        match self {
+            Create(action) => evm::trace::Action::Create(action.to_proto()),
+            Call(action) => evm::trace::Action::Call(action.to_proto()),
+            Selfdestruct(action) => evm::trace::Action::SelfDestruct(action.to_proto()),
+            Reward(action) => evm::trace::Action::Reward(action.to_proto()),
+        }
+    }
+}
+
+impl ModelExt for models::CallAction {
+    type Proto = evm::CallAction;
+
+    fn to_proto(&self) -> Self::Proto {
+        evm::CallAction {
+            from_address: self.from.to_proto().into(),
+            r#type: self.call_type.to_proto(),
+            gas: self.gas,
+            input: self.input.to_vec(),
+            to_address: self.to.to_proto().into(),
+            value: self.value.to_proto().into(),
+        }
+    }
+}
+
+impl ModelExt for models::CreateAction {
+    type Proto = evm::CreateAction;
+
+    fn to_proto(&self) -> Self::Proto {
+        evm::CreateAction {
+            from_address: self.from.to_proto().into(),
+            gas: self.gas,
+            init: self.init.to_vec(),
+            value: self.value.to_proto().into(),
+            creation_method: 0,
+        }
+    }
+}
+
+impl ModelExt for models::SelfdestructAction {
+    type Proto = evm::SelfDestructAction;
+
+    fn to_proto(&self) -> Self::Proto {
+        evm::SelfDestructAction {
+            address: self.address.to_proto().into(),
+            balance: self.balance.to_proto().into(),
+            refund_address: self.refund_address.to_proto().into(),
+        }
+    }
+}
+
+impl ModelExt for models::RewardAction {
+    type Proto = evm::RewardAction;
+
+    fn to_proto(&self) -> Self::Proto {
+        evm::RewardAction {
+            author: self.author.to_proto().into(),
+            r#type: self.reward_type.to_proto(),
+            value: self.value.to_proto().into(),
+        }
+    }
+}
+
+impl ModelExt for models::TraceOutput {
+    type Proto = evm::trace::Output;
+
+    fn to_proto(&self) -> Self::Proto {
+        use models::TraceOutput::*;
+
+        match self {
+            Call(output) => evm::trace::Output::CallOutput(output.to_proto()),
+            Create(output) => evm::trace::Output::CreateOutput(output.to_proto()),
+        }
+    }
+}
+
+impl ModelExt for models::CallOutput {
+    type Proto = evm::CallOutput;
+
+    fn to_proto(&self) -> Self::Proto {
+        evm::CallOutput {
+            gas_used: self.gas_used,
+            output: self.output.to_vec(),
+        }
+    }
+}
+
+impl ModelExt for models::CreateOutput {
+    type Proto = evm::CreateOutput;
+
+    fn to_proto(&self) -> Self::Proto {
+        evm::CreateOutput {
+            address: self.address.to_proto().into(),
+            code: self.code.to_vec(),
+            gas_used: self.gas_used,
+        }
+    }
+}
+
+impl ModelExt for models::CallType {
+    type Proto = i32;
+
+    fn to_proto(&self) -> Self::Proto {
+        use models::CallType::*;
+
+        match self {
+            None => evm::CallType::Unspecified as i32,
+            Call => evm::CallType::Call as i32,
+            CallCode => evm::CallType::CallCode as i32,
+            DelegateCall => evm::CallType::DelegateCall as i32,
+            StaticCall => evm::CallType::StaticCall as i32,
+            AuthCall => evm::CallType::AuthCall as i32,
+        }
+    }
+}
+
+impl ModelExt for models::RewardType {
+    type Proto = i32;
+
+    fn to_proto(&self) -> Self::Proto {
+        use models::RewardType::*;
+
+        match self {
+            Block => evm::RewardType::Block as i32,
+            Uncle => evm::RewardType::Uncle as i32,
+        }
+    }
+}
+
 impl ModelExt for models::B256 {
     type Proto = evm::B256;
 

--- a/evm/src/provider/models.rs
+++ b/evm/src/provider/models.rs
@@ -2,6 +2,11 @@ pub use alloy_primitives::{Address, Bloom, B256, U128, U256};
 pub use alloy_rpc_types::{
     AccessListItem, Block, Header, Log, Signature, Transaction, TransactionReceipt, Withdrawal,
 };
+pub use alloy_rpc_types_trace::parity::{
+    Action, CallAction, CallOutput, CallType, CreateAction, CreateOutput, RewardAction, RewardType,
+    SelfdestructAction, TraceOutput, TraceResults, TraceResultsWithTransactionHash,
+    TransactionTrace,
+};
 use apibara_dna_common::{chain::BlockInfo, Cursor, Hash};
 
 pub type BlockWithTxHashes = Block<B256>;

--- a/protocol/build.rs
+++ b/protocol/build.rs
@@ -35,7 +35,7 @@ fn main() -> Result<()> {
         .build_client(true)
         .build_server(true)
         .boxed(".starknet.v2.InvokeTransactionTrace.execute_invocation.success")
-        .boxed(".starknet.v2.Trace.trace_root.deploy_account")
+        .boxed(".starknet.v2.TransactionTrace.trace_root.deploy_account")
         .file_descriptor_set_path(out_dir.join(STARKNET_DESCRIPTOR_FILE))
         .compile_protos(
             &[

--- a/protocol/build.rs
+++ b/protocol/build.rs
@@ -34,6 +34,8 @@ fn main() -> Result<()> {
     tonic_build::configure()
         .build_client(true)
         .build_server(true)
+        .boxed(".starknet.v2.InvokeTransactionTrace.execute_invocation.success")
+        .boxed(".starknet.v2.Trace.trace_root.deploy_account")
         .file_descriptor_set_path(out_dir.join(STARKNET_DESCRIPTOR_FILE))
         .compile_protos(
             &[

--- a/protocol/proto/evm/v2/data.proto
+++ b/protocol/proto/evm/v2/data.proto
@@ -18,6 +18,8 @@ message Block {
   repeated TransactionReceipt receipts = 4;
   // List of logs.
   repeated Log logs = 5;
+  // List of transaction traces.
+  repeated TransactionTrace traces = 6;
 }
 
 // Block header.
@@ -201,4 +203,120 @@ enum TransactionStatus {
   TRANSACTION_STATUS_UNSPECIFIED = 0;
   TRANSACTION_STATUS_SUCCEEDED = 1;
   TRANSACTION_STATUS_REVERTED = 2;
+}
+
+message TransactionTrace {
+  repeated uint32 filter_ids = 1;
+  // Index of the transaction in the block.
+  uint32 transaction_index = 2;
+  // Transaction hash.
+  B256 transaction_hash = 3;
+  // Traces.
+  repeated Trace traces = 4;
+}
+
+message Trace {
+  // Represent the kind of action.
+  oneof action {
+    CallAction call = 1;
+    CreateAction create = 2;
+    SelfDestructAction self_destruct = 3;
+    RewardAction reward = 4;
+  }
+  // Error message if the transaction failed.
+  optional string error = 5;
+  oneof output {
+    // Output of a regular call.
+    CallOutput call_output = 6;
+    // Output of a create call.
+    CreateOutput create_output = 7;
+  }
+  // Number of sub traces.
+  uint32 subtraces = 8;
+  // The identifier of this trace in the trace tree.
+  repeated uint32 trace_address = 9;
+}
+
+message CallAction {
+  // Address of the sending account.
+  Address from_address = 1;
+  // Call type.
+  CallType type = 2;
+  // The gas available to execute the call.
+  uint64 gas = 3;
+  // Input data provided by the call.
+  bytes input = 4;
+  // Target of the destination address.
+  Address to_address = 5;
+  // Value transferred to the destination account.
+  U256 value = 6;
+}
+
+message CreateAction {
+  // Address of the sending account.
+  Address from_address = 1;
+  // The gas available to execute the call.
+  uint64 gas = 2;
+  // Input data provided by the call.
+  bytes init = 3;
+  // Value transferred to the ne account.
+  U256 value = 4;
+  // Contract creation method.
+  CreationMethod creation_method = 5;
+}
+
+message SelfDestructAction {
+  // The destroyed address.
+  Address address = 1;
+  // Balance of the destroyed account before destruct.
+  U256 balance = 2;
+  // The heir address.
+  Address refund_address = 3;
+}
+
+message RewardAction {
+  // The author's address.
+  Address author = 1;
+  // Reward type.
+  RewardType type = 2;
+  // The reward's value.
+  U256 value = 3;
+}
+
+message CallOutput {
+  // Gas used.
+  uint64 gas_used = 1;
+  // Output data.
+  bytes output = 2;
+}
+
+message CreateOutput {
+  // Contract address.
+  Address address = 1;
+  // Code
+  bytes code = 2;
+  // Gas used.
+  uint64 gas_used = 3;
+}
+
+enum CallType {
+  CALL_TYPE_UNSPECIFIED = 0;
+  CALL_TYPE_CALL = 1;
+  CALL_TYPE_CALL_CODE = 2;
+  CALL_TYPE_DELEGATE_CALL = 3;
+  CALL_TYPE_STATIC_CALL = 4;
+  CALL_TYPE_AUTH_CALL = 5;
+}
+
+enum CreationMethod {
+  CREATION_METHOD_UNSPECIFIED = 0;
+  CREATION_METHOD_CREATE = 1;
+  CREATION_METHOD_CREATE2 = 2;
+  CREATION_METHOD_EOF_CREATE = 3;
+}
+
+enum RewardType {
+  REWARD_TYPE_UNSPECIFIED = 0;
+  REWARD_TYPE_BLOCK = 1;
+  REWARD_TYPE_UNCLE = 2;
 }

--- a/protocol/proto/evm/v2/filter.proto
+++ b/protocol/proto/evm/v2/filter.proto
@@ -47,6 +47,8 @@ message TransactionFilter {
   optional bool include_receipt = 6;
   // Flag to request the transaction's logs. Defaults to `false`.
   optional bool include_logs = 7;
+  // Flag to request the transaction's trace. Defaults to `false`.
+  optional bool include_transaction_trace = 8;
 }
 
 message LogFilter {
@@ -71,6 +73,8 @@ message LogFilter {
   //
   // Defaults to false.
   optional bool include_siblings = 8;
+  // Flag to request the log's trace. Defaults to `false`.
+  optional bool include_transaction_trace = 9;
 }
 
 // Topic filter.

--- a/protocol/proto/starknet/v2/data.proto
+++ b/protocol/proto/starknet/v2/data.proto
@@ -25,7 +25,7 @@ message Block {
   // List of nonce updates.
   repeated NonceUpdate nonce_updates = 8;
   // List of transaction traces.
-  repeated Trace traces = 9;
+  repeated TransactionTrace traces = 9;
 }
 
 // Block header.
@@ -458,7 +458,7 @@ message NonceUpdate {
   FieldElement nonce = 3;
 }
 
-message Trace {
+message TransactionTrace {
   repeated uint32 filter_ids = 1;
   // Index of the transaction in the block.
   uint32 transaction_index = 2;

--- a/protocol/proto/starknet/v2/data.proto
+++ b/protocol/proto/starknet/v2/data.proto
@@ -24,6 +24,8 @@ message Block {
   repeated ContractChange contract_changes = 7;
   // List of nonce updates.
   repeated NonceUpdate nonce_updates = 8;
+  // List of transaction traces.
+  repeated Trace traces = 9;
 }
 
 // Block header.
@@ -454,4 +456,69 @@ message NonceUpdate {
   FieldElement contract_address = 2;
   // New nonce value.
   FieldElement nonce = 3;
+}
+
+message Trace {
+  repeated uint32 filter_ids = 1;
+  // Transaction hash.
+  FieldElement transaction_hash = 2;
+
+  oneof trace_root {
+    InvokeTransactionTrace invoke = 3;
+    DeclareTransactionTrace declare = 4;
+    DeployAccountTransactionTrace deploy_account = 5;
+    L1HandlerTransactionTrace l1_handler = 6;
+  }
+}
+
+message InvokeTransactionTrace {
+  FunctionInvocation validate_invocation = 1;
+
+  oneof execute_invocation {
+    FunctionInvocation success = 2;
+    ExecutionReverted reverted = 3;
+  }
+
+  FunctionInvocation fee_transfer_invocation = 4;
+}
+
+message DeclareTransactionTrace {
+  FunctionInvocation validate_invocation = 1;
+  FunctionInvocation fee_transfer_invocation = 2;
+}
+
+message DeployAccountTransactionTrace {
+  FunctionInvocation validate_invocation = 1;
+  FunctionInvocation constructor_invocation = 2;
+  FunctionInvocation fee_transfer_invocation = 3;
+}
+
+message L1HandlerTransactionTrace {
+  FunctionInvocation function_invocation = 2;
+}
+
+message FunctionInvocation {
+  FieldElement contract_address = 1;
+  FieldElement entry_point_selector = 2;
+  repeated FieldElement calldata = 3;
+  FieldElement caller_address = 4;
+  FieldElement class_hash = 5;
+  CallType call_type = 6;
+  repeated FieldElement result = 7;
+  repeated FunctionInvocation calls = 8;
+  repeated uint32 events = 9;
+  repeated uint32 messages = 10;
+}
+
+message FunctionCall {
+  FieldElement contract_address = 1;
+  FieldElement entry_point_selector = 2;
+  repeated FieldElement calldata = 3;
+}
+
+enum CallType {
+  CALL_TYPE_UNSPECIFIED = 0;
+  CALL_TYPE_LIBRARY_CALL = 1;
+  CALL_TYPE_CALL = 2;
+  CALL_TYPE_DELEGATE = 3;
 }

--- a/protocol/proto/starknet/v2/data.proto
+++ b/protocol/proto/starknet/v2/data.proto
@@ -460,14 +460,16 @@ message NonceUpdate {
 
 message Trace {
   repeated uint32 filter_ids = 1;
+  // Index of the transaction in the block.
+  uint32 transaction_index = 2;
   // Transaction hash.
-  FieldElement transaction_hash = 2;
+  FieldElement transaction_hash = 3;
 
   oneof trace_root {
-    InvokeTransactionTrace invoke = 3;
-    DeclareTransactionTrace declare = 4;
-    DeployAccountTransactionTrace deploy_account = 5;
-    L1HandlerTransactionTrace l1_handler = 6;
+    InvokeTransactionTrace invoke = 4;
+    DeclareTransactionTrace declare = 5;
+    DeployAccountTransactionTrace deploy_account = 6;
+    L1HandlerTransactionTrace l1_handler = 7;
   }
 }
 

--- a/protocol/proto/starknet/v2/filter.proto
+++ b/protocol/proto/starknet/v2/filter.proto
@@ -60,6 +60,10 @@ message EventFilter {
   //
   // Defaults to false.
   optional bool include_siblings = 9;
+  // Include the trace of the transaction that emitted the event.
+  //
+  // Defaults to false.
+  optional bool include_transaction_trace = 10;
 }
 
 message Key {
@@ -94,6 +98,10 @@ message MessageToL1Filter {
   //
   // Defaults to false.
   optional bool include_siblings = 8;
+  // Include the trace of the transaction that sent the message.
+  //
+  // Defaults to false.
+  optional bool include_transaction_trace = 9;
 }
 
 // Filter transactions.
@@ -129,6 +137,11 @@ message TransactionFilter {
     DeployAccountV1TransactionFilter deploy_account_v1 = 15;
     DeployAccountV3TransactionFilter deploy_account_v3 = 16;
   }
+
+  // Flag to request the transaction's trace.
+  //
+  // Defaults to `false``.
+  optional bool include_trace = 17;
 }
 
 message InvokeTransactionV0Filter {}

--- a/starknet/Cargo.toml
+++ b/starknet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.25"
+version = "2.0.0-beta.26"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/starknet/src/cli/start.rs
+++ b/starknet/src/cli/start.rs
@@ -22,6 +22,14 @@ pub struct StartCommand {
         default_value = "false"
     )]
     no_ingest_pending: bool,
+
+    /// Ingest traces.
+    #[arg(
+        long = "starknet.ingest-traces",
+        env = "STARKNET_INGEST_TRACES",
+        default_value = "false"
+    )]
+    ingest_traces: bool,
 }
 
 impl StartCommand {
@@ -30,6 +38,7 @@ impl StartCommand {
         let provider = self.rpc.to_starknet_provider()?;
         let starknet_ingestion_options = StarknetBlockIngestionOptions {
             ingest_pending: !self.no_ingest_pending,
+            ingest_traces: self.ingest_traces,
         };
         let starknet_chain = StarknetChainSupport::new(provider, starknet_ingestion_options);
 

--- a/starknet/src/filter/event.rs
+++ b/starknet/src/filter/event.rs
@@ -7,7 +7,7 @@ use apibara_dna_protocol::starknet;
 use crate::fragment::{
     EVENT_FRAGMENT_ID, INDEX_EVENT_BY_ADDRESS, INDEX_EVENT_BY_KEY0, INDEX_EVENT_BY_KEY1,
     INDEX_EVENT_BY_KEY2, INDEX_EVENT_BY_KEY3, INDEX_EVENT_BY_KEY_LENGTH,
-    INDEX_EVENT_BY_TRANSACTION_STATUS, MESSAGE_FRAGMENT_ID, RECEIPT_FRAGMENT_ID,
+    INDEX_EVENT_BY_TRANSACTION_STATUS, MESSAGE_FRAGMENT_ID, RECEIPT_FRAGMENT_ID, TRACE_FRAGMENT_ID,
     TRANSACTION_FRAGMENT_ID,
 };
 
@@ -102,6 +102,10 @@ impl FragmentFilterExt for starknet::EventFilter {
 
         if let Some(true) = self.include_siblings {
             joins.push(EVENT_FRAGMENT_ID);
+        }
+
+        if let Some(true) = self.include_transaction_trace {
+            joins.push(TRACE_FRAGMENT_ID);
         }
 
         Ok(Filter {

--- a/starknet/src/filter/message.rs
+++ b/starknet/src/filter/message.rs
@@ -7,7 +7,7 @@ use apibara_dna_protocol::starknet;
 use crate::fragment::{
     EVENT_FRAGMENT_ID, INDEX_MESSAGE_BY_FROM_ADDRESS, INDEX_MESSAGE_BY_TO_ADDRESS,
     INDEX_MESSAGE_BY_TRANSACTION_STATUS, MESSAGE_FRAGMENT_ID, RECEIPT_FRAGMENT_ID,
-    TRANSACTION_FRAGMENT_ID,
+    TRACE_FRAGMENT_ID, TRANSACTION_FRAGMENT_ID,
 };
 
 use super::helpers::FragmentFilterExt;
@@ -74,6 +74,10 @@ impl FragmentFilterExt for starknet::MessageToL1Filter {
 
         if let Some(true) = self.include_siblings {
             joins.push(MESSAGE_FRAGMENT_ID);
+        }
+
+        if let Some(true) = self.include_transaction_trace {
+            joins.push(TRACE_FRAGMENT_ID);
         }
 
         Ok(Filter {

--- a/starknet/src/filter/transaction.rs
+++ b/starknet/src/filter/transaction.rs
@@ -6,7 +6,7 @@ use apibara_dna_protocol::starknet;
 
 use crate::fragment::{
     EVENT_FRAGMENT_ID, INDEX_TRANSACTION_BY_STATUS, INDEX_TRANSACTION_BY_TYPE, MESSAGE_FRAGMENT_ID,
-    RECEIPT_FRAGMENT_ID, TRANSACTION_FRAGMENT_ID,
+    RECEIPT_FRAGMENT_ID, TRACE_FRAGMENT_ID, TRANSACTION_FRAGMENT_ID,
 };
 
 use super::helpers::FragmentFilterExt;
@@ -96,6 +96,10 @@ impl FragmentFilterExt for starknet::TransactionFilter {
 
         if let Some(true) = self.include_messages {
             joins.push(MESSAGE_FRAGMENT_ID);
+        }
+
+        if let Some(true) = self.include_trace {
+            joins.push(TRACE_FRAGMENT_ID);
         }
 
         Ok(Filter {

--- a/starknet/src/fragment.rs
+++ b/starknet/src/fragment.rs
@@ -23,6 +23,9 @@ pub const CONTRACT_CHANGE_FRAGMENT_NAME: &str = "contract_change";
 pub const NONCE_UPDATE_FRAGMENT_ID: u8 = 8;
 pub const NONCE_UPDATE_FRAGMENT_NAME: &str = "nonce_update";
 
+pub const TRACE_FRAGMENT_ID: u8 = 9;
+pub const TRACE_FRAGMENT_NAME: &str = "trace";
+
 pub const INDEX_TRANSACTION_BY_STATUS: u8 = 0;
 pub const INDEX_TRANSACTION_BY_TYPE: u8 = 1;
 
@@ -45,3 +48,5 @@ pub const INDEX_STORAGE_DIFF_BY_CONTRACT_ADDRESS: u8 = 0;
 pub const INDEX_CONTRACT_CHANGE_BY_TYPE: u8 = 0;
 
 pub const INDEX_NONCE_UPDATE_BY_CONTRACT_ADDRESS: u8 = 0;
+
+// No trace indexes.

--- a/starknet/src/ingestion.rs
+++ b/starknet/src/ingestion.rs
@@ -472,7 +472,9 @@ fn collect_block_body_and_index(
 
     for transaction_trace in transaction_traces.iter() {
         let transaction_index = block_traces.len() as u32;
-        let trace = transaction_trace.to_proto();
+        let mut trace = transaction_trace.to_proto();
+
+        trace.transaction_index = transaction_index;
 
         join_transaction_to_trace.insert(transaction_index, transaction_index);
 

--- a/starknet/src/lib.rs
+++ b/starknet/src/lib.rs
@@ -4,8 +4,8 @@ use fragment::{
     CONTRACT_CHANGE_FRAGMENT_ID, CONTRACT_CHANGE_FRAGMENT_NAME, EVENT_FRAGMENT_ID,
     EVENT_FRAGMENT_NAME, MESSAGE_FRAGMENT_ID, MESSAGE_FRAGMENT_NAME, NONCE_UPDATE_FRAGMENT_ID,
     NONCE_UPDATE_FRAGMENT_NAME, RECEIPT_FRAGMENT_ID, RECEIPT_FRAGMENT_NAME,
-    STORAGE_DIFF_FRAGMENT_ID, STORAGE_DIFF_FRAGMENT_NAME, TRANSACTION_FRAGMENT_ID,
-    TRANSACTION_FRAGMENT_NAME,
+    STORAGE_DIFF_FRAGMENT_ID, STORAGE_DIFF_FRAGMENT_NAME, TRACE_FRAGMENT_ID, TRACE_FRAGMENT_NAME,
+    TRANSACTION_FRAGMENT_ID, TRANSACTION_FRAGMENT_NAME,
 };
 use ingestion::StarknetBlockIngestion;
 use provider::StarknetProvider;
@@ -64,6 +64,10 @@ impl ChainSupport for StarknetChainSupport {
             FragmentInfo {
                 fragment_id: NONCE_UPDATE_FRAGMENT_ID,
                 name: NONCE_UPDATE_FRAGMENT_NAME.to_string(),
+            },
+            FragmentInfo {
+                fragment_id: TRACE_FRAGMENT_ID,
+                name: TRACE_FRAGMENT_NAME.to_string(),
             },
         ]
     }

--- a/starknet/src/proto.rs
+++ b/starknet/src/proto.rs
@@ -827,10 +827,10 @@ impl ModelExt for models::NonceUpdate {
 }
 
 impl ModelExt for models::TransactionTraceWithHash {
-    type Proto = starknet::Trace;
+    type Proto = starknet::TransactionTrace;
 
     fn to_proto(&self) -> Self::Proto {
-        starknet::Trace {
+        starknet::TransactionTrace {
             filter_ids: Vec::default(),
             transaction_index: u32::MAX,
             transaction_hash: self.transaction_hash.to_proto().into(),
@@ -840,7 +840,7 @@ impl ModelExt for models::TransactionTraceWithHash {
 }
 
 impl ModelExt for models::TransactionTrace {
-    type Proto = starknet::trace::TraceRoot;
+    type Proto = starknet::transaction_trace::TraceRoot;
 
     fn to_proto(&self) -> Self::Proto {
         use models::TransactionTrace::*;
@@ -855,7 +855,7 @@ impl ModelExt for models::TransactionTrace {
 }
 
 impl ModelExt for models::InvokeTransactionTrace {
-    type Proto = starknet::trace::TraceRoot;
+    type Proto = starknet::transaction_trace::TraceRoot;
 
     fn to_proto(&self) -> Self::Proto {
         let inner = starknet::InvokeTransactionTrace {
@@ -867,12 +867,12 @@ impl ModelExt for models::InvokeTransactionTrace {
                 .map(ModelExt::to_proto),
         };
 
-        starknet::trace::TraceRoot::Invoke(inner)
+        starknet::transaction_trace::TraceRoot::Invoke(inner)
     }
 }
 
 impl ModelExt for models::DeployAccountTransactionTrace {
-    type Proto = starknet::trace::TraceRoot;
+    type Proto = starknet::transaction_trace::TraceRoot;
 
     fn to_proto(&self) -> Self::Proto {
         let inner = starknet::DeployAccountTransactionTrace {
@@ -884,24 +884,24 @@ impl ModelExt for models::DeployAccountTransactionTrace {
                 .map(ModelExt::to_proto),
         };
 
-        starknet::trace::TraceRoot::DeployAccount(inner.into())
+        starknet::transaction_trace::TraceRoot::DeployAccount(inner.into())
     }
 }
 
 impl ModelExt for models::L1HandlerTransactionTrace {
-    type Proto = starknet::trace::TraceRoot;
+    type Proto = starknet::transaction_trace::TraceRoot;
 
     fn to_proto(&self) -> Self::Proto {
         let inner = starknet::L1HandlerTransactionTrace {
             function_invocation: self.function_invocation.to_proto().into(),
         };
 
-        starknet::trace::TraceRoot::L1Handler(inner)
+        starknet::transaction_trace::TraceRoot::L1Handler(inner)
     }
 }
 
 impl ModelExt for models::DeclareTransactionTrace {
-    type Proto = starknet::trace::TraceRoot;
+    type Proto = starknet::transaction_trace::TraceRoot;
 
     fn to_proto(&self) -> Self::Proto {
         let inner = starknet::DeclareTransactionTrace {
@@ -912,7 +912,7 @@ impl ModelExt for models::DeclareTransactionTrace {
                 .map(ModelExt::to_proto),
         };
 
-        starknet::trace::TraceRoot::Declare(inner)
+        starknet::transaction_trace::TraceRoot::Declare(inner)
     }
 }
 

--- a/starknet/src/proto.rs
+++ b/starknet/src/proto.rs
@@ -825,3 +825,157 @@ impl ModelExt for models::NonceUpdate {
         }
     }
 }
+
+impl ModelExt for models::TransactionTraceWithHash {
+    type Proto = starknet::Trace;
+
+    fn to_proto(&self) -> Self::Proto {
+        starknet::Trace {
+            filter_ids: Vec::default(),
+            transaction_hash: self.transaction_hash.to_proto().into(),
+            trace_root: self.trace_root.to_proto().into(),
+        }
+    }
+}
+
+impl ModelExt for models::TransactionTrace {
+    type Proto = starknet::trace::TraceRoot;
+
+    fn to_proto(&self) -> Self::Proto {
+        use models::TransactionTrace::*;
+
+        match self {
+            Invoke(inner) => inner.to_proto(),
+            DeployAccount(inner) => inner.to_proto(),
+            L1Handler(inner) => inner.to_proto(),
+            Declare(inner) => inner.to_proto(),
+        }
+    }
+}
+
+impl ModelExt for models::InvokeTransactionTrace {
+    type Proto = starknet::trace::TraceRoot;
+
+    fn to_proto(&self) -> Self::Proto {
+        let inner = starknet::InvokeTransactionTrace {
+            validate_invocation: self.validate_invocation.as_ref().map(ModelExt::to_proto),
+            execute_invocation: self.execute_invocation.to_proto().into(),
+            fee_transfer_invocation: self
+                .fee_transfer_invocation
+                .as_ref()
+                .map(ModelExt::to_proto),
+        };
+
+        starknet::trace::TraceRoot::Invoke(inner)
+    }
+}
+
+impl ModelExt for models::DeployAccountTransactionTrace {
+    type Proto = starknet::trace::TraceRoot;
+
+    fn to_proto(&self) -> Self::Proto {
+        let inner = starknet::DeployAccountTransactionTrace {
+            validate_invocation: self.validate_invocation.as_ref().map(ModelExt::to_proto),
+            constructor_invocation: self.constructor_invocation.to_proto().into(),
+            fee_transfer_invocation: self
+                .fee_transfer_invocation
+                .as_ref()
+                .map(ModelExt::to_proto),
+        };
+
+        starknet::trace::TraceRoot::DeployAccount(inner.into())
+    }
+}
+
+impl ModelExt for models::L1HandlerTransactionTrace {
+    type Proto = starknet::trace::TraceRoot;
+
+    fn to_proto(&self) -> Self::Proto {
+        let inner = starknet::L1HandlerTransactionTrace {
+            function_invocation: self.function_invocation.to_proto().into(),
+        };
+
+        starknet::trace::TraceRoot::L1Handler(inner)
+    }
+}
+
+impl ModelExt for models::DeclareTransactionTrace {
+    type Proto = starknet::trace::TraceRoot;
+
+    fn to_proto(&self) -> Self::Proto {
+        let inner = starknet::DeclareTransactionTrace {
+            validate_invocation: self.validate_invocation.as_ref().map(ModelExt::to_proto),
+            fee_transfer_invocation: self
+                .fee_transfer_invocation
+                .as_ref()
+                .map(ModelExt::to_proto),
+        };
+
+        starknet::trace::TraceRoot::Declare(inner)
+    }
+}
+
+impl ModelExt for models::ExecuteInvocation {
+    type Proto = starknet::invoke_transaction_trace::ExecuteInvocation;
+
+    fn to_proto(&self) -> Self::Proto {
+        use models::ExecuteInvocation::*;
+
+        match self {
+            Success(invocation) => starknet::invoke_transaction_trace::ExecuteInvocation::Success(
+                invocation.to_proto().into(),
+            ),
+            Reverted(reason) => {
+                let inner = starknet::ExecutionReverted {
+                    reason: reason.revert_reason.clone(),
+                };
+                starknet::invoke_transaction_trace::ExecuteInvocation::Reverted(inner)
+            }
+        }
+    }
+}
+
+impl ModelExt for models::FunctionInvocation {
+    type Proto = starknet::FunctionInvocation;
+
+    fn to_proto(&self) -> Self::Proto {
+        starknet::FunctionInvocation {
+            contract_address: self.contract_address.to_proto().into(),
+            entry_point_selector: self.entry_point_selector.to_proto().into(),
+            calldata: self.calldata.iter().map(ModelExt::to_proto).collect(),
+            caller_address: self.caller_address.to_proto().into(),
+            class_hash: self.class_hash.to_proto().into(),
+            call_type: self.call_type.to_proto(),
+            result: self.result.iter().map(ModelExt::to_proto).collect(),
+            calls: self.calls.iter().map(ModelExt::to_proto).collect(),
+            events: self.events.iter().map(|ev| ev.order as u32).collect(),
+            messages: self.messages.iter().map(|msg| msg.order as u32).collect(),
+        }
+    }
+}
+
+impl ModelExt for models::FunctionCall {
+    type Proto = starknet::FunctionCall;
+
+    fn to_proto(&self) -> Self::Proto {
+        starknet::FunctionCall {
+            contract_address: self.contract_address.to_proto().into(),
+            entry_point_selector: self.entry_point_selector.to_proto().into(),
+            calldata: self.calldata.iter().map(ModelExt::to_proto).collect(),
+        }
+    }
+}
+
+impl ModelExt for models::CallType {
+    type Proto = i32;
+
+    fn to_proto(&self) -> Self::Proto {
+        use models::CallType::*;
+
+        match *self {
+            LibraryCall => starknet::CallType::LibraryCall as i32,
+            Call => starknet::CallType::Call as i32,
+            Delegate => starknet::CallType::Delegate as i32,
+        }
+    }
+}

--- a/starknet/src/proto.rs
+++ b/starknet/src/proto.rs
@@ -832,6 +832,7 @@ impl ModelExt for models::TransactionTraceWithHash {
     fn to_proto(&self) -> Self::Proto {
         starknet::Trace {
             filter_ids: Vec::default(),
+            transaction_index: u32::MAX,
             transaction_hash: self.transaction_hash.to_proto().into(),
             trace_root: self.trace_root.to_proto().into(),
         }

--- a/starknet/src/provider/models.rs
+++ b/starknet/src/provider/models.rs
@@ -1,17 +1,20 @@
 use apibara_dna_common::{Cursor, Hash};
 pub use starknet::core::types::{
-    BlockWithReceipts, ComputationResources, ContractStorageDiffItem, DataAvailabilityMode,
-    DataResources, DeclareTransaction, DeclareTransactionReceipt, DeclareTransactionV0,
-    DeclareTransactionV1, DeclareTransactionV2, DeclareTransactionV3, DeclaredClassItem,
-    DeployAccountTransaction, DeployAccountTransactionReceipt, DeployAccountTransactionV1,
+    BlockWithReceipts, CallType, ComputationResources, ContractStorageDiffItem,
+    DataAvailabilityMode, DataResources, DeclareTransaction, DeclareTransactionReceipt,
+    DeclareTransactionTrace, DeclareTransactionV0, DeclareTransactionV1, DeclareTransactionV2,
+    DeclareTransactionV3, DeclaredClassItem, DeployAccountTransaction,
+    DeployAccountTransactionReceipt, DeployAccountTransactionTrace, DeployAccountTransactionV1,
     DeployAccountTransactionV3, DeployTransaction, DeployTransactionReceipt, DeployedContractItem,
-    Event, ExecutionResources, ExecutionResult, FeePayment, Felt as FieldElement,
-    InvokeTransaction, InvokeTransactionReceipt, InvokeTransactionV0, InvokeTransactionV1,
+    Event, ExecuteInvocation, ExecutionResources, ExecutionResult, FeePayment,
+    Felt as FieldElement, FunctionCall, FunctionInvocation, InvokeTransaction,
+    InvokeTransactionReceipt, InvokeTransactionTrace, InvokeTransactionV0, InvokeTransactionV1,
     InvokeTransactionV3, L1DataAvailabilityMode, L1HandlerTransaction, L1HandlerTransactionReceipt,
-    MaybePendingBlockWithReceipts, MaybePendingBlockWithTxHashes, MaybePendingStateUpdate, MsgToL1,
-    NonceUpdate, PendingBlockWithReceipts, PendingStateUpdate, PriceUnit, ReplacedClassItem,
-    ResourceBounds, ResourceBoundsMapping, ResourcePrice, StateDiff, StateUpdate, StorageEntry,
-    Transaction, TransactionReceipt, TransactionWithReceipt,
+    L1HandlerTransactionTrace, MaybePendingBlockWithReceipts, MaybePendingBlockWithTxHashes,
+    MaybePendingStateUpdate, MsgToL1, NonceUpdate, PendingBlockWithReceipts, PendingStateUpdate,
+    PriceUnit, ReplacedClassItem, ResourceBounds, ResourceBoundsMapping, ResourcePrice, StateDiff,
+    StateUpdate, StorageEntry, Transaction, TransactionReceipt, TransactionTrace,
+    TransactionTraceWithHash, TransactionWithReceipt,
 };
 
 pub trait BlockExt {


### PR DESCRIPTION
### Summary

This PR adds support for transaction traces both on Starknet and EVM chains.

For now, traces can be requested when filtering transaction and/or logs.
In the future, it will be possible to filter traces based on their attributes.
