### PR TITLE
Prune grouped/segmented blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.27"
+version = "2.0.0-beta.28"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -669,7 +669,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.27"
+version = "2.0.0-beta.28"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.27"
+version = "2.0.0-beta.28"
 dependencies = [
  "apibara-dna-common",
  "apibara-dna-protocol",

--- a/beaconchain/Cargo.toml
+++ b/beaconchain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.27"
+version = "2.0.0-beta.28"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/common/src/compaction/metrics.rs
+++ b/common/src/compaction/metrics.rs
@@ -5,6 +5,7 @@ pub struct CompactionMetrics {
     pub up: Gauge<u64>,
     pub segmented: Gauge<u64>,
     pub grouped: Gauge<u64>,
+    pub pruned: Gauge<u64>,
     pub block_download: RequestMetrics,
     pub segment_creation: RequestMetrics,
     pub segment_upload: RequestMetrics,
@@ -31,6 +32,10 @@ impl Default for CompactionMetrics {
             grouped: meter
                 .u64_gauge("dna.compaction.grouped")
                 .with_description("dna compaction most recent grouped block")
+                .build(),
+            pruned: meter
+                .u64_gauge("dna.compaction.pruned")
+                .with_description("dna compaction most recent pruned block")
                 .build(),
             block_download: RequestMetrics::new("dna_compaction", "dna.compaction.block_download"),
             segment_creation: RequestMetrics::new(

--- a/common/src/compaction/mod.rs
+++ b/common/src/compaction/mod.rs
@@ -3,6 +3,7 @@ mod error;
 mod group;
 mod group_builder;
 mod metrics;
+mod prune;
 mod segment;
 mod segment_builder;
 mod service;

--- a/common/src/compaction/prune.rs
+++ b/common/src/compaction/prune.rs
@@ -1,0 +1,124 @@
+use error_stack::{Result, ResultExt};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info};
+
+use crate::{
+    block_store::BlockStoreWriter, chain_view::ChainView, ingestion::IngestionStateClient,
+};
+
+use super::{metrics::CompactionMetrics, CompactionError};
+
+pub struct PruneService {
+    segment_size: usize,
+    chain_view: ChainView,
+    block_store_writer: BlockStoreWriter,
+    state_client: IngestionStateClient,
+    metrics: CompactionMetrics,
+}
+
+impl PruneService {
+    pub fn new(
+        segment_size: usize,
+        chain_view: ChainView,
+        block_store_writer: BlockStoreWriter,
+        state_client: IngestionStateClient,
+        metrics: CompactionMetrics,
+    ) -> Self {
+        Self {
+            segment_size,
+            chain_view,
+            block_store_writer,
+            state_client,
+            metrics,
+        }
+    }
+
+    pub async fn start(mut self, ct: CancellationToken) -> Result<(), CompactionError> {
+        loop {
+            if ct.is_cancelled() {
+                return Ok(());
+            }
+
+            info!("compaction: prune tick");
+
+            self.prune_loop(&ct).await?;
+
+            info!("compaction: pruned up to the grouped segment");
+
+            let Some(_) = ct
+                .run_until_cancelled(self.chain_view.segmented_changed())
+                .await
+            else {
+                return Ok(());
+            };
+        }
+    }
+
+    async fn prune_loop(&mut self, ct: &CancellationToken) -> Result<(), CompactionError> {
+        let Some(grouped) = self
+            .state_client
+            .get_grouped()
+            .await
+            .change_context(CompactionError)?
+        else {
+            debug!("no grouped block, skipping pruning");
+            return Ok(());
+        };
+
+        let starting_block = if let Some(pruned_block) = self
+            .state_client
+            .get_pruned()
+            .await
+            .change_context(CompactionError)?
+        {
+            pruned_block
+        } else {
+            let genesis = self
+                .chain_view
+                .get_starting_cursor()
+                .await
+                .change_context(CompactionError)?;
+            genesis.number
+        };
+
+        debug!(starting_block, grouped, "prune loop starting");
+
+        let mut current_pruned_block = starting_block;
+
+        while current_pruned_block < grouped {
+            for _ in 0..self.segment_size {
+                if ct.is_cancelled() {
+                    return Ok(());
+                }
+
+                if current_pruned_block > grouped {
+                    break;
+                }
+
+                debug!(block = current_pruned_block, "pruning block");
+
+                self.block_store_writer
+                    .delete_block_with_prefix(current_pruned_block)
+                    .await
+                    .change_context(CompactionError)
+                    .attach_printable("failed to delete block")
+                    .attach_printable_lazy(|| format!("block number: {current_pruned_block}"))?;
+
+                current_pruned_block += 1;
+            }
+
+            let last_pruned_block = current_pruned_block - 1;
+
+            debug!(block = last_pruned_block, "updating pruned block in state");
+
+            self.state_client
+                .put_pruned(last_pruned_block)
+                .await
+                .change_context(CompactionError)?;
+
+            self.metrics.pruned.record(last_pruned_block, &[]);
+        }
+
+        Ok(())
+    }
+}

--- a/common/src/object_store/aws_s3.rs
+++ b/common/src/object_store/aws_s3.rs
@@ -124,6 +124,32 @@ impl AwsS3Client {
         Ok(etag)
     }
 
+    pub async fn list_objects(
+        &self,
+        bucket: &str,
+        prefix: &str,
+    ) -> Result<Vec<String>, ObjectStoreError> {
+        let response = self
+            .0
+            .list_objects()
+            .bucket(bucket)
+            .prefix(prefix)
+            .send()
+            .await
+            .change_to_object_store_context()?;
+
+        let mut object_ids = Vec::default();
+        for object in response.contents() {
+            let object_id = object
+                .key()
+                .ok_or(ObjectStoreError::Metadata)
+                .attach_printable("missing key")?;
+            object_ids.push(object_id.to_string());
+        }
+
+        Ok(object_ids)
+    }
+
     pub async fn delete_object(
         &self,
         bucket: &str,

--- a/common/src/object_store/client.rs
+++ b/common/src/object_store/client.rs
@@ -52,6 +52,17 @@ impl ObjectStoreClient {
         }
     }
 
+    pub async fn list_objects(
+        &self,
+        bucket: &str,
+        prefix: &str,
+    ) -> Result<Vec<String>, ObjectStoreError> {
+        match self {
+            Self::AwsS3(client) => client.list_objects(bucket, prefix).await,
+            Self::AzureBlob(client) => client.list_objects(bucket, prefix).await,
+        }
+    }
+
     pub async fn delete_object(
         &self,
         bucket: &str,

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.27"
+version = "2.0.0-beta.28"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/starknet/Cargo.toml
+++ b/starknet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.27"
+version = "2.0.0-beta.28"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
### Summary

This PR improves the compaction service to also prune blocks that now belong to a segment that has been grouped.
This blocks are not needed and can be safely removed, reducing data stored on S3 by ~50%.
