### PR TITLE
Fix DNA stream server reliability issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.29"
+version = "2.0.0-beta.30"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.29"
+version = "2.0.0-beta.30"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.29"
+version = "2.0.0-beta.30"
 dependencies = [
  "apibara-dna-common",
  "apibara-dna-protocol",

--- a/beaconchain/Cargo.toml
+++ b/beaconchain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.29"
+version = "2.0.0-beta.30"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/common/src/chain.rs
+++ b/common/src/chain.rs
@@ -440,14 +440,30 @@ impl CanonicalChainSegment {
                     .attach_printable_lazy(|| format!("last block: {:?}", self.info.last_block));
             };
 
-            let siblings = reorgs.reorgs.values().cloned().collect::<Vec<_>>();
+            // Reorgs is a map between block hash (the block that was reorged)
+            // and reorg target cursor (the most recent common block between the
+            // old and new chain).
+            let siblings = reorgs
+                .reorgs
+                .keys()
+                .cloned()
+                .map(|hash| Cursor::new(cursor.number, hash))
+                .collect::<Vec<_>>();
             return Ok(siblings);
         }
 
         let offset = cursor.number - self.info.first_block.number;
 
         let canonical = &self.canonical[offset as usize];
-        let siblings = canonical.reorgs.values().cloned().collect::<Vec<_>>();
+        // Reorgs is a map between block hash (the block that was reorged) and
+        // reorg target cursor (the most recent common block between the old and
+        // new chain).
+        let siblings = canonical
+            .reorgs
+            .keys()
+            .cloned()
+            .map(|hash| Cursor::new(cursor.number, hash))
+            .collect::<Vec<_>>();
         Ok(siblings)
     }
 

--- a/common/src/chain_view/view.rs
+++ b/common/src/chain_view/view.rs
@@ -264,6 +264,18 @@ impl ChainView {
 
         Ok(())
     }
+
+    pub async fn record_is_down(&self) -> Result<(), ChainViewError> {
+        let inner = self.0.write().await;
+        inner.metrics.up.record(0, &[]);
+        Ok(())
+    }
+
+    pub async fn record_is_up(&self) -> Result<(), ChainViewError> {
+        let inner = self.0.write().await;
+        inner.metrics.up.record(1, &[]);
+        Ok(())
+    }
 }
 
 impl ChainViewInner {

--- a/common/src/chain_view/view.rs
+++ b/common/src/chain_view/view.rs
@@ -238,15 +238,12 @@ impl ChainView {
     pub(crate) async fn refresh_recent(&self) -> Result<(), ChainViewError> {
         let mut inner = self.0.write().await;
 
-        let prev_head = inner.canonical.get_head().await?;
         inner.canonical.refresh_recent().await?;
         let new_head = inner.canonical.get_head().await?;
-        debug!(?prev_head, ?new_head, "refresh recent head");
+        debug!(?new_head, "refresh recent head");
 
-        if prev_head != new_head {
-            inner.metrics.head.record(new_head.number, &[]);
-            inner.head_notify.notify_waiters();
-        }
+        inner.metrics.head.record(new_head.number, &[]);
+        inner.head_notify.notify_waiters();
 
         Ok(())
     }

--- a/common/src/chain_view/view.rs
+++ b/common/src/chain_view/view.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use error_stack::Result;
 use tokio::sync::{Notify, RwLock};
+use tracing::debug;
 
 use crate::Cursor;
 
@@ -240,6 +241,7 @@ impl ChainView {
         let prev_head = inner.canonical.get_head().await?;
         inner.canonical.refresh_recent().await?;
         let new_head = inner.canonical.get_head().await?;
+        debug!(?prev_head, ?new_head, "refresh recent head");
 
         if prev_head != new_head {
             inner.metrics.head.record(new_head.number, &[]);

--- a/common/src/object_store/azure_blob.rs
+++ b/common/src/object_store/azure_blob.rs
@@ -78,7 +78,13 @@ impl AzureBlobClient {
                 let content = response.blob.properties.etag.as_ref().to_string();
                 etag = Some(ObjectETag(content));
             }
-            while let Some(data) = response.data.try_next().await.unwrap() {
+
+            while let Some(data) = response
+                .data
+                .try_next()
+                .await
+                .change_to_object_store_context()?
+            {
                 output.extend_from_slice(&data);
             }
         }

--- a/develop/docker-compose.etcd.yaml
+++ b/develop/docker-compose.etcd.yaml
@@ -1,0 +1,15 @@
+# Run etcd
+services:
+  etcd:
+    image: bitnami/etcd:latest
+    environment:
+    - ALLOW_NONE_AUTHENTICATION=yes
+    - ETCD_ADVERTISE_CLIENT_URLS=http://etcd:2379
+    ports:
+    - "2379:2379"
+    - "2380:2380"
+    volumes:
+    - etcd_data:/bitnami/etcd
+
+volumes:
+  etcd_data:

--- a/develop/docker-compose.no-etcd.yaml
+++ b/develop/docker-compose.no-etcd.yaml
@@ -1,0 +1,54 @@
+# All services except etcd.
+# Used to test running without etcd
+services:
+  minio:
+    image: minio/minio:latest
+    ports:
+    - "9000:9000"
+    - "9001:9001"
+    volumes:
+    - minio_data:/data
+    environment:
+      MINIO_ROOT_USER: "minioadmin"
+      MINIO_ROOT_PASSWORD: "minioadmin"
+    command: ["server", "/data", "--console-address", ":9001"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+
+  opentelemetry-collector:
+    image: otel/opentelemetry-collector:latest
+    ports:
+    - "4317:4317"
+    volumes:
+    - ./opentelemetry-collector:/etc/opentelemetry-collector
+    command:
+    - '--config=/etc/opentelemetry-collector/config.yaml'
+
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+    - ./prometheus:/etc/prometheus:ro
+    command:
+    - '--config.file=/etc/prometheus/prometheus.yaml'
+    - '--storage.tsdb.path=/prometheus'
+    - '--web.enable-remote-write-receiver'
+    ports:
+    - 9090:9090
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+    - 3000:3000
+    volumes:
+    - grafana_data:/var/lib/grafana
+    - ./grafana/datasources:/etc/grafana/provisioning/datasources
+    environment:
+    - GF_SECURITY_ADMIN_USER=admin
+    - GF_SECURITY_ADMIN_PASSWORD=admin
+    - GF_USERS_ALLOW_SIGN_UP=false
+
+volumes:
+  minio_data:
+  grafana_data:

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.29"
+version = "2.0.0-beta.30"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/starknet/Cargo.toml
+++ b/starknet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.29"
+version = "2.0.0-beta.30"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
### Summary

This PR fixes a couple of minor DNA stream server reliability issues:

 - Correctly detect cursor _siblings_ on stream start. Previously, the function was returning the _reorg target_ cursors.
 - Keep the stream server running when the etcd client disconnects. Now, the server keeps streaming historical data to clients and will resume serving live data once the etcd state client comes back online.
