### PR TITLE
Change pending block to not be considered live

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.31"
+version = "2.0.0-beta.32"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.31"
+version = "2.0.0-beta.32"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.31"
+version = "2.0.0-beta.32"
 dependencies = [
  "apibara-dna-common",
  "apibara-dna-protocol",

--- a/beaconchain/Cargo.toml
+++ b/beaconchain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.31"
+version = "2.0.0-beta.32"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/common/src/data_stream/stream.rs
+++ b/common/src/data_stream/stream.rs
@@ -439,8 +439,11 @@ impl DataStream {
         let fragment_access = FragmentAccess::Block(block_entry);
 
         let mut blocks = Vec::new();
+        // We send pending blocks only if they contain data.
+        // This avoids a bug where an empty pending block is not followed by its
+        // accepted version, but by the block after it.
         if self
-            .filter_fragment(fragment_access, &finality, true, &mut blocks)
+            .filter_fragment(fragment_access, &finality, false, &mut blocks)
             .await?
         {
             use sha2::Digest;

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.31"
+version = "2.0.0-beta.32"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/starknet/Cargo.toml
+++ b/starknet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.31"
+version = "2.0.0-beta.32"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
### Summary

Previously, the pending block was considered "live" and so, if the user
requested to receive all live blocks, was sent even if empty.

This caused an issue when blocks `n` and `n+1` were discovered by the service
at the same time, since the client never received the accepted version of `n`.

This PR changes the live block behaviour to the following:

 - pending blocks are sent only if they contain data.
 - accepted blocks are sent if empty, if the client requested it.

### Testing strategy

We tested this by listening by running an indexer with the following filter:

```ts
const filter = {
  header: "on_data_or_on_new_block",
  logs: [
    {
      // wBTC on Ethereum mainnet.
      address: "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
    },
  ],
};
```

This filter occasionally produces pending data, but not always.

The following run trace shows the block number, hash, finality, production and number of logs.

Notice that the pending blocks contain data, while block `xxx296` and `xxx301`
are empty but their pending version was not sent by the server.

```txt
22590295n 0x27d67ef4bbe536b31c91c2d0180a0204e459908a65af7c42ab77d4784489d524 accepted live 6
22590296n 0x5bae0611331f29b4750677d6222dc8add1ccc2a0cf879680ae350a988605f178 accepted live 0

22590297n 0xbfaa75d65e240dc6ac5344d10172202bd760cc390ef314554581218d497329c1 pending live 2
22590297n 0xf8f0d459e0531103e59045a7a1130a4d89a02d70d387202a1a1b06011287f06f pending live 2
22590297n 0xf8f0d459e0531103e59045a7a1130a4d89a02d70d387202a1a1b06011287f06f accepted live 2

22590298n 0x845aa2fc51af09b425ea338431f8b45e0a2b864f212dcfc313c24371977237f8 accepted live 3
22590299n 0xd68f7ce2f3238b2a574122d104fccf7a59a11b19b206225ae40d5c83941e8a32 accepted live 1
22590300n 0x82d903ac77fb7530240648369735542be22a452dd7c15539aeeb82c9c092fda5 accepted live 1
22590301n 0x6aa560f875d4eaf1480e6bab52d3894874cdf96b919de1f3c2490fc22011b1b8 accepted live 0
```
