### PR TITLE
Avoid sending empty block with joins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.32"
+version = "2.0.0-beta.33"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.32"
+version = "2.0.0-beta.33"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.32"
+version = "2.0.0-beta.33"
 dependencies = [
  "apibara-dna-common",
  "apibara-dna-protocol",

--- a/beaconchain/Cargo.toml
+++ b/beaconchain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-beaconchain"
-version = "2.0.0-beta.32"
+version = "2.0.0-beta.33"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/common/src/data_stream/stream.rs
+++ b/common/src/data_stream/stream.rs
@@ -513,6 +513,10 @@ impl DataStream {
                     let rows = filter.filter(indexes).change_context(DataStreamError)?;
                     filter_match.add_match(filter.filter_id, &rows);
 
+                    if rows.is_empty() {
+                        continue;
+                    }
+
                     for join_with_fragment_id in filter.joins.iter() {
                         joins
                             .entry((*fragment_id, *join_with_fragment_id))

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-evm"
-version = "2.0.0-beta.32"
+version = "2.0.0-beta.33"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/starknet/Cargo.toml
+++ b/starknet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apibara-dna-starknet"
-version = "2.0.0-beta.32"
+version = "2.0.0-beta.33"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
### Summary

The current implementation sends an empty block if joins are present.
This PR fixes that, sending blocks only if there is data.
