### PR TITLE
chore: Added `Send + Sync` for `BearerTokenProvider` & `BearerTokenError` dyn errors

### DIFF
--- a/sdk/src/auth.rs
+++ b/sdk/src/auth.rs
@@ -16,12 +16,12 @@ pub enum BearerTokenError {
     #[snafu(display("{message}"))]
     External {
         message: String,
-        source: Box<dyn std::error::Error>,
+        source: Box<dyn std::error::Error + Send + Sync>,
     },
 }
 
 /// An object that provides a bearer token to authenticate with the DNA server.
-pub trait BearerTokenProvider {
+pub trait BearerTokenProvider: Send + Sync {
     /// Get the bearer token.
     ///
     /// Notice that this method is _not_ async. If you need to fetch the token


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

  1. If this is your first pull request, please read our contribution
  guidelines in CONTRIBUTING.md
  2. If the PR is not ready for merging but you want early feedback, add
  '[WIP]' in your PR title and mark it as Draft.
  3. Be sure to keep the PR description updated to reflect all changes.
-->

### Summary

<!--
Please provide a brief summary of this PR. The summary will help us
craft the CHANGELOG for the next release.
-->

* When working with the indexer, I could not spawn the stream processing in a new tokio thread cause `Send` & `Sync` were missing as trait constraints.

### Testing strategy

<!--
How did you test that your code is working? For example:

Before this PR:
- run `apibara-sink-postgres` using a connection string that requires a SSL
connection.
- note that the sinks exits with an error.
After:
- run the sink with the same connection string as before.
- note that the sink is working and writes data to the database.
-->

* Used my fork for our project & it compiled correctly with those additions.
