### PR TITLE
common: shrink canonical chain more aggressively

### DIFF
--- a/common/src/ingestion/service.rs
+++ b/common/src/ingestion/service.rs
@@ -558,7 +558,7 @@ where
                 .change_context(IngestionError::Model)?;
 
             if self.chain_builder.segment_size()
-                == self.options.chain_segment_size + self.options.chain_segment_upload_offset_size
+                >= self.options.chain_segment_size + self.options.chain_segment_upload_offset_size
             {
                 let segment = self
                     .chain_builder


### PR DESCRIPTION
### Summary

This fixes a bug where if the reorg happens at the right time, the canonical chain is never shrunk.
