### PR TITLE
starknet: disable pre-confirmed ingestion

### DIFF
--- a/common/src/file_cache.rs
+++ b/common/src/file_cache.rs
@@ -6,7 +6,7 @@ use clap::Args;
 use error_stack::{Result, ResultExt};
 use foyer::{
     BlockEngineConfig, CacheEntry, Compression, DeviceBuilder, FsDeviceBuilder, HybridCache,
-    HybridCacheBuilder, HybridGetOrFetch, RecoverMode, S3FifoConfig,
+    HybridCacheBuilder, HybridGetOrFetch, PsyncIoEngineConfig, RecoverMode, S3FifoConfig,
 };
 
 #[derive(Debug)]
@@ -184,6 +184,7 @@ impl FileCacheArgs {
                 .with_weighter(|_: &String, bytes: &Bytes| bytes.len())
                 .storage()
                 .with_compression(compression)
+                .with_io_engine_config(PsyncIoEngineConfig::new())
                 .with_engine_config(
                     BlockEngineConfig::new(device)
                         .with_block_size(block_size as _)
@@ -234,6 +235,7 @@ impl FileCacheArgs {
                 .with_weighter(|_: &String, bytes: &Bytes| bytes.len())
                 .storage()
                 .with_compression(compression)
+                .with_io_engine_config(PsyncIoEngineConfig::new())
                 .with_engine_config(
                     BlockEngineConfig::new(device)
                         .with_block_size(block_size as _)

--- a/starknet/src/cli/start.rs
+++ b/starknet/src/cli/start.rs
@@ -15,14 +15,6 @@ pub struct StartCommand {
     #[clap(flatten)]
     start: StartArgs,
 
-    /// Do NOT ingest and serve pending blocks.
-    #[arg(
-        long = "starknet.no-ingest-pending",
-        env = "STARKNET_NO_INGEST_PENDING",
-        default_value = "false"
-    )]
-    no_ingest_pending: bool,
-
     /// Ingest traces.
     #[arg(
         long = "starknet.ingest-traces",
@@ -37,7 +29,7 @@ impl StartCommand {
         info!("Starting Starknet DNA server");
         let provider = self.rpc.to_starknet_provider()?;
         let starknet_ingestion_options = StarknetBlockIngestionOptions {
-            ingest_pending: !self.no_ingest_pending,
+            ingest_pending: false,
             ingest_traces: self.ingest_traces,
         };
         let starknet_chain = StarknetChainSupport::new(provider, starknet_ingestion_options);


### PR DESCRIPTION
This avoids people pushing a configuration that doesn't work to production.