### PR TITLE
Add Starknet websocket live ingestion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,8 +696,11 @@ dependencies = [
  "futures",
  "hex",
  "prost 0.14.3",
+ "serde",
+ "serde_json",
  "tokio",
  "tokio-stream",
+ "tokio-tungstenite",
  "tokio-util",
  "tonic 0.14.5",
  "tracing",
@@ -1849,7 +1852,6 @@ dependencies = [
  "dyn-clone",
  "futures",
  "getrandom 0.2.17",
- "hmac",
  "http-types",
  "once_cell",
  "paste",
@@ -1860,7 +1862,6 @@ dependencies = [
  "rustc_version 0.4.1",
  "serde",
  "serde_json",
- "sha2 0.10.9",
  "time",
  "tracing",
  "url",
@@ -1883,7 +1884,6 @@ dependencies = [
  "serde",
  "time",
  "tracing",
- "tz-rs",
  "url",
  "uuid 1.23.0",
 ]
@@ -2500,12 +2500,6 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
-name = "const_fn"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413d67b29ef1021b4d60f4aa1e925ca031751e213832b4b1d588fae623c05c60"
 
 [[package]]
 name = "const_format"
@@ -3346,21 +3340,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4076,6 +4055,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4088,22 +4068,6 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.9.0",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -4840,23 +4804,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nix"
 version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5058,48 +5005,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "openssl"
-version = "0.10.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.113"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -6120,20 +6029,21 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
- "hyper-tls",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "js-sys",
  "log",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls 0.23.38",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower 0.5.3",
  "tower-http",
@@ -6143,6 +6053,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -7569,16 +7480,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7618,9 +7519,11 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "native-tls",
+ "rustls 0.23.38",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls 0.26.4",
  "tungstenite",
 ]
 
@@ -7987,8 +7890,9 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "native-tls",
  "rand 0.9.4",
+ "rustls 0.23.38",
+ "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -8008,15 +7912,6 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
-name = "tz-rs"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
-dependencies = [
- "const_fn",
-]
 
 [[package]]
 name = "ucd-trie"
@@ -8193,12 +8088,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -8417,6 +8306,15 @@ name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ prost-types = "0.14.3"
 rand = "0.10.1"
 reqwest = { version = "0.13.2", default-features = false, features = [
     "json",
-    "default-tls"
+    "rustls"
 ] }
 rkyv = { version = "0.8.15", features = ["unaligned"] }
 roaring = "0.11.3"

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -25,8 +25,11 @@ futures.workspace = true
 error-stack.workspace = true
 hex.workspace = true
 prost.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 tonic.workspace = true
 tokio.workspace = true
 tokio-stream = { version = "0.1.18", features = ["sync", "net"] }
+tokio-tungstenite = { version = "0.26.0", features = ["rustls-tls-native-roots"] }
 tokio-util.workspace = true
 tracing.workspace = true

--- a/benchmark/src/lib.rs
+++ b/benchmark/src/lib.rs
@@ -1,18 +1,25 @@
 use std::{
+    collections::HashMap,
     str::FromStr,
     time::{Duration, Instant},
 };
 
 use apibara_dna_protocol::{
-    dna::stream::{dna_stream_client::DnaStreamClient, Cursor, StreamDataRequest},
+    dna::stream::{
+        dna_stream_client::DnaStreamClient, stream_data_response, Cursor, DataFinality,
+        StreamDataRequest,
+    },
     evm, starknet,
 };
 use byte_unit::Byte;
 use clap::{Args, Parser, Subcommand};
 use error_stack::{Result, ResultExt};
-use futures::{StreamExt, TryStreamExt};
+use futures::{SinkExt, StreamExt, TryStreamExt};
 use prost::Message;
+use serde_json::Value;
+use tokio::sync::mpsc;
 use tokio::task::JoinSet;
+use tokio_tungstenite::tungstenite::Message as WsMessage;
 use tokio_util::sync::CancellationToken;
 use tonic::{metadata::AsciiMetadataValue, IntoRequest};
 use tracing::{info, warn};
@@ -33,6 +40,8 @@ pub enum Command {
     Evm(CommonArgs),
     /// Benchmark the Starknet DNA stream.
     Starknet(CommonArgs),
+    /// Compare direct Starknet subscribeEvents latency with DNA pending stream latency.
+    StarknetLiveLatency(StarknetLiveLatencyArgs),
 }
 
 #[derive(Args, Debug, Clone)]
@@ -56,6 +65,34 @@ pub struct CommonArgs {
     pub concurrency: usize,
 }
 
+#[derive(Args, Debug, Clone)]
+pub struct StarknetLiveLatencyArgs {
+    /// Direct Starknet WebSocket RPC URL.
+    #[clap(long, default_value = "ws://64.34.87.87:9545/ws/rpc/v0_10")]
+    pub direct_ws_url: String,
+    /// DNA stream URL.
+    #[clap(long, default_value = "http://localhost:7007")]
+    pub stream_url: String,
+    /// Bearer token used for DNA stream authentication.
+    #[clap(long)]
+    pub bearer_token: Option<String>,
+    /// Death Mountain GameCore contract address.
+    #[clap(long)]
+    pub game_core_address: String,
+    /// GameEvent selector key, for example sn_keccak(\"GameEvent\") padded as a felt hex string.
+    #[clap(long)]
+    pub game_event_key: String,
+    /// Optional keyed-layout adventurer id. If omitted, all GameEvent events are matched.
+    #[clap(long)]
+    pub adventurer_id: Option<String>,
+    /// Benchmark duration in seconds.
+    #[clap(long, default_value = "120")]
+    pub duration_secs: u64,
+    /// Stop once this many matching events have been observed.
+    #[clap(long, default_value = "20")]
+    pub min_samples: usize,
+}
+
 impl Cli {
     pub async fn run(self, ct: CancellationToken) -> Result<(), BenchmarkError> {
         match self.command {
@@ -63,6 +100,7 @@ impl Cli {
             Command::Starknet(args) => {
                 run_benchmark::<starknet::Filter, StarknetStats>(args, ct).await
             }
+            Command::StarknetLiveLatency(args) => run_starknet_live_latency(args, ct).await,
         }
     }
 }
@@ -192,6 +230,413 @@ where
     stats.print_summary();
 
     Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct EventIdentity {
+    transaction_hash: String,
+    event_index_in_transaction: u32,
+    from_address: String,
+    keys: Vec<String>,
+    data: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct EventObservation {
+    identity: EventIdentity,
+    seen_at: Instant,
+    block_number: Option<u64>,
+    finality: String,
+    event_index: Option<u32>,
+}
+
+#[derive(Debug, Default)]
+struct EventMatchState {
+    direct: Option<EventObservation>,
+    dna: Option<EventObservation>,
+    printed: bool,
+}
+
+async fn run_starknet_live_latency(
+    args: StarknetLiveLatencyArgs,
+    ct: CancellationToken,
+) -> Result<(), BenchmarkError> {
+    let (direct_tx, mut direct_rx) = mpsc::channel(1024);
+    let (dna_tx, mut dna_rx) = mpsc::channel(1024);
+
+    let direct_task = tokio::spawn(run_direct_subscribe_events(
+        args.clone(),
+        direct_tx,
+        ct.clone(),
+    ));
+    let dna_task = tokio::spawn(run_dna_starknet_events(args.clone(), dna_tx, ct.clone()));
+
+    println!(
+        "txHash,blockNumber,eventIndex,finality,directSubscribeEventsSeenMs,dnaStreamSeenMs,dnaMinusSubscribeEventsMs"
+    );
+
+    let start = Instant::now();
+    let deadline = tokio::time::sleep(Duration::from_secs(args.duration_secs));
+    tokio::pin!(deadline);
+
+    let mut matches = HashMap::<EventIdentity, EventMatchState>::new();
+    let mut latencies = Vec::<i128>::new();
+
+    loop {
+        tokio::select! {
+            _ = ct.cancelled() => break,
+            _ = &mut deadline => break,
+            Some(observation) = direct_rx.recv() => {
+                record_observation(observation, true, start, &mut matches, &mut latencies);
+            }
+            Some(observation) = dna_rx.recv() => {
+                record_observation(observation, false, start, &mut matches, &mut latencies);
+            }
+            else => break,
+        }
+
+        if latencies.len() >= args.min_samples {
+            break;
+        }
+    }
+
+    ct.cancel();
+    direct_task.abort();
+    dna_task.abort();
+    finish_latency_task(direct_task, "direct subscribeEvents").await?;
+    finish_latency_task(dna_task, "DNA stream").await?;
+
+    print_latency_summary(&latencies);
+
+    Ok(())
+}
+
+async fn finish_latency_task(
+    task: tokio::task::JoinHandle<Result<(), BenchmarkError>>,
+    label: &str,
+) -> Result<(), BenchmarkError> {
+    match task.await {
+        Ok(result) => result,
+        Err(err) if err.is_cancelled() => Ok(()),
+        Err(err) => Err(err)
+            .change_context(BenchmarkError)
+            .attach_printable_lazy(|| format!("{label} task failed")),
+    }
+}
+
+fn record_observation(
+    observation: EventObservation,
+    is_direct: bool,
+    start: Instant,
+    matches: &mut HashMap<EventIdentity, EventMatchState>,
+    latencies: &mut Vec<i128>,
+) {
+    let state = matches.entry(observation.identity.clone()).or_default();
+
+    if is_direct {
+        if state.direct.is_none() {
+            state.direct = Some(observation);
+        }
+    } else if state.dna.is_none() {
+        state.dna = Some(observation);
+    }
+
+    let (Some(direct), Some(dna)) = (&state.direct, &state.dna) else {
+        return;
+    };
+
+    if state.printed {
+        return;
+    }
+
+    state.printed = true;
+
+    let latency_ms = signed_duration_ms(dna.seen_at, direct.seen_at);
+    latencies.push(latency_ms);
+
+    let block_number = dna.block_number.or(direct.block_number).unwrap_or_default();
+    let event_index = dna.event_index.unwrap_or_default();
+    let direct_seen_ms = signed_duration_ms(direct.seen_at, start);
+    let dna_seen_ms = signed_duration_ms(dna.seen_at, start);
+
+    println!(
+        "{},{},{},{},{},{},{}",
+        dna.identity.transaction_hash,
+        block_number,
+        event_index,
+        dna.finality,
+        direct_seen_ms,
+        dna_seen_ms,
+        latency_ms
+    );
+}
+
+fn print_latency_summary(latencies: &[i128]) {
+    if latencies.is_empty() {
+        println!("summary,count=0,p95DnaMinusSubscribeEventsMs=");
+        return;
+    }
+
+    let mut sorted = latencies.to_vec();
+    sorted.sort_unstable();
+    let p95_index = ((sorted.len() * 95).div_ceil(100)).saturating_sub(1);
+    let p95 = sorted[p95_index];
+    let max = sorted[sorted.len() - 1];
+
+    println!(
+        "summary,count={},p95DnaMinusSubscribeEventsMs={},maxDnaMinusSubscribeEventsMs={}",
+        sorted.len(),
+        p95,
+        max
+    );
+}
+
+fn signed_duration_ms(later: Instant, earlier: Instant) -> i128 {
+    if later >= earlier {
+        later.duration_since(earlier).as_millis() as i128
+    } else {
+        -(earlier.duration_since(later).as_millis() as i128)
+    }
+}
+
+async fn run_direct_subscribe_events(
+    args: StarknetLiveLatencyArgs,
+    tx: mpsc::Sender<EventObservation>,
+    ct: CancellationToken,
+) -> Result<(), BenchmarkError> {
+    let (ws_stream, _) = tokio_tungstenite::connect_async(&args.direct_ws_url)
+        .await
+        .change_context(BenchmarkError)
+        .attach_printable("failed to connect direct Starknet websocket")?;
+    let (mut write, mut read) = ws_stream.split();
+
+    let mut keys = vec![vec![normalize_hex_result(&args.game_event_key)?]];
+    if let Some(adventurer_id) = &args.adventurer_id {
+        keys.push(vec![normalize_hex_result(adventurer_id)?]);
+    }
+
+    let subscribe = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "starknet_subscribeEvents",
+        "params": {
+            "from_address": normalize_hex_result(&args.game_core_address)?,
+            "keys": keys,
+            "finality_status": "PRE_CONFIRMED"
+        }
+    });
+
+    write
+        .send(WsMessage::Text(subscribe.to_string().into()))
+        .await
+        .change_context(BenchmarkError)
+        .attach_printable("failed to send starknet_subscribeEvents request")?;
+
+    while !ct.is_cancelled() {
+        tokio::select! {
+            _ = ct.cancelled() => break,
+            message = read.next() => {
+                let Some(message) = message else {
+                    break;
+                };
+                let message = message
+                    .change_context(BenchmarkError)
+                    .attach_printable("direct Starknet websocket read failed")?;
+                let WsMessage::Text(text) = message else {
+                    continue;
+                };
+
+                if let Some(observation) = parse_direct_event(&text) {
+                    if tx.send(observation).await.is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn run_dna_starknet_events(
+    args: StarknetLiveLatencyArgs,
+    tx: mpsc::Sender<EventObservation>,
+    ct: CancellationToken,
+) -> Result<(), BenchmarkError> {
+    let mut client = DnaStreamClient::connect(args.stream_url.clone())
+        .await
+        .change_context(BenchmarkError)
+        .attach_printable("failed to connect DNA stream")?;
+
+    let game_core_address = starknet::FieldElement::from_hex(&args.game_core_address)
+        .change_context(BenchmarkError)
+        .attach_printable("failed to parse game core address")?;
+    let game_event_key = starknet::FieldElement::from_hex(&args.game_event_key)
+        .change_context(BenchmarkError)
+        .attach_printable("failed to parse game event key")?;
+    let adventurer_id = args
+        .adventurer_id
+        .as_deref()
+        .map(starknet::FieldElement::from_hex)
+        .transpose()
+        .change_context(BenchmarkError)
+        .attach_printable("failed to parse adventurer id")?;
+
+    let mut event_keys = vec![starknet::Key {
+        value: Some(game_event_key),
+    }];
+    if let Some(adventurer_id) = adventurer_id {
+        event_keys.push(starknet::Key {
+            value: Some(adventurer_id),
+        });
+    }
+
+    let filter = starknet::Filter {
+        header: starknet::HeaderFilter::OnData as i32,
+        events: vec![starknet::EventFilter {
+            address: Some(game_core_address),
+            keys: event_keys,
+            strict: Some(false),
+            include_receipt: Some(true),
+            include_transaction: Some(false),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    let mut request = StreamDataRequest {
+        finality: Some(DataFinality::Pending as i32),
+        filter: vec![filter.encode_to_vec()],
+        ..Default::default()
+    }
+    .into_request();
+
+    if let Some(bearer_token) = args.bearer_token {
+        let authorization_value = format!("Bearer {bearer_token}");
+        let authorization_value = AsciiMetadataValue::from_str(&authorization_value)
+            .change_context(BenchmarkError)
+            .attach_printable("failed to parse authorization value")?;
+        request
+            .metadata_mut()
+            .insert("authorization", authorization_value);
+    }
+
+    let stream = client
+        .stream_data(request)
+        .await
+        .change_context(BenchmarkError)
+        .attach_printable("failed to start DNA stream")?
+        .into_inner()
+        .take_until(async move { ct.cancelled().await });
+    tokio::pin!(stream);
+
+    while let Some(message) = stream.try_next().await.change_context(BenchmarkError)? {
+        let Some(stream_data_response::Message::Data(data)) = message.message else {
+            continue;
+        };
+
+        let finality = DataFinality::try_from(data.finality)
+            .map(|f| format!("{f:?}"))
+            .unwrap_or_else(|_| format!("UNKNOWN({})", data.finality));
+
+        for block_bytes in data.data {
+            let block = starknet::Block::decode(block_bytes.as_ref())
+                .change_context(BenchmarkError)
+                .attach_printable("failed to decode Starknet DNA block")?;
+            let block_number = block.header.as_ref().map(|header| header.block_number);
+
+            for event in block.events {
+                if let Some(identity) = dna_event_identity(&event) {
+                    let observation = EventObservation {
+                        identity,
+                        seen_at: Instant::now(),
+                        block_number,
+                        finality: finality.clone(),
+                        event_index: Some(event.event_index),
+                    };
+
+                    if tx.send(observation).await.is_err() {
+                        return Ok(());
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_direct_event(text: &str) -> Option<EventObservation> {
+    let value: Value = serde_json::from_str(text).ok()?;
+    if value.get("method").and_then(Value::as_str)? != "starknet_subscriptionEvents" {
+        return None;
+    }
+
+    let result = value.get("params")?.get("result")?;
+
+    let transaction_hash = normalize_hex_value(result.get("transaction_hash")?.as_str()?)?;
+    let event_index_in_transaction = result.get("event_index")?.as_u64()?.try_into().ok()?;
+    let from_address = normalize_hex_value(result.get("from_address")?.as_str()?)?;
+    let keys = normalize_hex_array(result.get("keys")?)?;
+    let data = normalize_hex_array(result.get("data")?)?;
+    let block_number = result.get("block_number").and_then(Value::as_u64);
+    let finality = result
+        .get("finality_status")
+        .and_then(Value::as_str)
+        .unwrap_or("UNKNOWN")
+        .to_string();
+
+    Some(EventObservation {
+        identity: EventIdentity {
+            transaction_hash,
+            event_index_in_transaction,
+            from_address,
+            keys,
+            data,
+        },
+        seen_at: Instant::now(),
+        block_number,
+        finality,
+        event_index: None,
+    })
+}
+
+fn dna_event_identity(event: &starknet::Event) -> Option<EventIdentity> {
+    Some(EventIdentity {
+        transaction_hash: event.transaction_hash.as_ref()?.to_hex(),
+        event_index_in_transaction: event.event_index_in_transaction,
+        from_address: event.from_address.as_ref()?.to_hex(),
+        keys: event
+            .keys
+            .iter()
+            .map(starknet::FieldElement::to_hex)
+            .collect(),
+        data: event
+            .data
+            .iter()
+            .map(starknet::FieldElement::to_hex)
+            .collect(),
+    })
+}
+
+fn normalize_hex_array(value: &Value) -> Option<Vec<String>> {
+    value
+        .as_array()?
+        .iter()
+        .map(|item| normalize_hex_value(item.as_str()?))
+        .collect()
+}
+
+fn normalize_hex_result(value: &str) -> Result<String, BenchmarkError> {
+    Ok(starknet::FieldElement::from_hex(value)
+        .change_context(BenchmarkError)?
+        .to_hex())
+}
+
+fn normalize_hex_value(value: &str) -> Option<String> {
+    starknet::FieldElement::from_hex(value)
+        .ok()
+        .map(|felt| felt.to_hex())
 }
 
 trait Stats {

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -17,10 +17,10 @@ apibara-observability = { path = "../observability" }
 apibara-dna-protocol = { path = "../protocol" }
 aws-config = { version = "1.8.15", features = ["behavior-version-latest"] }
 aws-sdk-s3 = "1.129.0"
-azure_identity = "0.21.0"
-azure_storage = "0.21.0"
-azure_storage_blobs = "0.21.0"
-azure_core = "0.21.0"
+azure_identity = { version = "0.21.0", default-features = false, features = ["enable_reqwest_rustls"] }
+azure_storage = { version = "0.21.0", default-features = false, features = ["enable_reqwest_rustls"] }
+azure_storage_blobs = { version = "0.21.0", default-features = false, features = ["enable_reqwest_rustls"] }
+azure_core = { version = "0.21.0", default-features = false, features = ["enable_reqwest_rustls"] }
 bytes.workspace = true
 byte-unit.workspace = true
 clap.workspace = true

--- a/common/src/ingestion/mod.rs
+++ b/common/src/ingestion/mod.rs
@@ -17,7 +17,8 @@ pub use self::cli::IngestionArgs;
 pub use self::error::{IngestionError, IngestionErrorExt};
 pub use self::metrics::IngestionMetrics;
 pub use self::service::{
-    BlockIngestion, BoxedNewHeadsStream, IngestionService, IngestionServiceOptions,
+    BlockIngestion, BoxedNewHeadsStream, BoxedPendingBlockUpdateStream, IngestionService,
+    IngestionServiceOptions,
 };
 pub use self::state_client::{
     IngestionStateClient, IngestionStateClientError, IngestionStateUpdate, FINALIZED_KEY,

--- a/common/src/ingestion/service.rs
+++ b/common/src/ingestion/service.rs
@@ -32,6 +32,8 @@ use super::{error::IngestionError, metrics::IngestionMetrics, state_client::Inge
 
 pub type BoxedNewHeadsStream =
     Pin<Box<dyn Stream<Item = Result<Cursor, IngestionError>> + Send + 'static>>;
+pub type BoxedPendingBlockUpdateStream =
+    Pin<Box<dyn Stream<Item = Result<(), IngestionError>> + Send + 'static>>;
 
 pub trait BlockIngestion: Clone {
     fn supports_pending(&self) -> bool {
@@ -64,6 +66,12 @@ pub trait BlockIngestion: Clone {
     fn new_heads_stream(
         &self,
     ) -> impl Future<Output = Result<BoxedNewHeadsStream, IngestionError>> + Send {
+        async { Ok(futures::stream::pending().boxed()) }
+    }
+
+    fn pending_block_updates_stream(
+        &self,
+    ) -> impl Future<Output = Result<BoxedPendingBlockUpdateStream, IngestionError>> + Send {
         async { Ok(futures::stream::pending().boxed()) }
     }
 }
@@ -142,6 +150,8 @@ pub struct IngestState {
     head_refresh_interval: Interval,
     finalized_refresh_interval: Interval,
     new_heads_stream: Pin<Box<dyn Stream<Item = Result<Cursor, IngestionError>> + Send>>,
+    pending_block_updates_stream:
+        Pin<Box<dyn Stream<Item = Result<(), IngestionError>> + Send + 'static>>,
 }
 
 impl fmt::Debug for IngestState {
@@ -159,6 +169,7 @@ impl fmt::Debug for IngestState {
                 &self.finalized_refresh_interval,
             )
             .field("new_heads_stream", &"<stream>")
+            .field("pending_block_updates_stream", &"<stream>")
             .finish()
     }
 }
@@ -307,6 +318,8 @@ where
                 info!(cursor = %starting_cursor, "uploaded genesis block");
 
                 let new_heads_stream = self.ingestion.new_heads_stream().await;
+                let pending_block_updates_stream =
+                    self.ingestion.pending_block_updates_stream().await;
 
                 Ok(IngestionState::Ingest(IngestState {
                     queued_block_number: starting_cursor.number,
@@ -324,12 +337,15 @@ where
                         self.options.finalized_refresh_interval,
                     ),
                     new_heads_stream,
+                    pending_block_updates_stream,
                 }))
             }
             IngestionStartAction::Resume(starting_cursor) => {
                 current_span.record("starting_block", starting_cursor.number);
 
                 let new_heads_stream = self.ingestion.new_heads_stream().await;
+                let pending_block_updates_stream =
+                    self.ingestion.pending_block_updates_stream().await;
 
                 Ok(IngestionState::Ingest(IngestState {
                     queued_block_number: starting_cursor.number,
@@ -347,6 +363,7 @@ where
                         self.options.finalized_refresh_interval,
                     ),
                     new_heads_stream,
+                    pending_block_updates_stream,
                 }))
             }
         }
@@ -355,7 +372,7 @@ where
     /// A single tick of ingestion.
     ///
     /// This is equivalent to `viewStep` in the Quint spec.
-    async fn tick_ingest(
+    pub async fn tick_ingest(
         &mut self,
         mut state: IngestState,
         ct: CancellationToken,
@@ -389,6 +406,30 @@ where
                     None => {
                         warn!("new heads stream ended, reconnecting");
                         state.new_heads_stream = self.ingestion.new_heads_stream().await;
+                        Ok(IngestionState::Ingest(state))
+                    }
+                }
+            }
+
+            result = state.pending_block_updates_stream.next(), if self.ingestion.supports_pending() => {
+                match result {
+                    Some(Ok(())) => {
+                        current_span.record("action", "pending_block_update_stream");
+
+                        // Reset the backup pending refresher because the push path already
+                        // scheduled a pending block refresh.
+                        state.pending_refresh_interval.reset();
+
+                        self.tick_refresh_pending(state).await
+                    }
+                    Some(Err(err)) => {
+                        warn!(error = ?err, "pending block update stream error, reconnecting");
+                        state.pending_block_updates_stream = self.ingestion.pending_block_updates_stream().await;
+                        Ok(IngestionState::Ingest(state))
+                    }
+                    None => {
+                        warn!("pending block update stream ended, reconnecting");
+                        state.pending_block_updates_stream = self.ingestion.pending_block_updates_stream().await;
                         Ok(IngestionState::Ingest(state))
                     }
                 }
@@ -753,6 +794,7 @@ where
         info!(new_head = %new_head_candidate, "recovered from a chain reorganization");
 
         let new_heads_stream = self.ingestion.new_heads_stream().await;
+        let pending_block_updates_stream = self.ingestion.pending_block_updates_stream().await;
 
         Ok(IngestionState::Ingest(IngestState {
             finalized: state.finalized,
@@ -766,6 +808,7 @@ where
                 self.options.finalized_refresh_interval,
             ),
             new_heads_stream,
+            pending_block_updates_stream,
         }))
     }
 
@@ -873,6 +916,16 @@ where
             Ok(stream) => stream,
             Err(e) => {
                 tracing::warn!("failed to get new heads stream: {:?}", e);
+                futures::stream::pending().boxed()
+            }
+        }
+    }
+
+    async fn pending_block_updates_stream(&self) -> BoxedPendingBlockUpdateStream {
+        match self.ingestion.pending_block_updates_stream().await {
+            Ok(stream) => stream,
+            Err(e) => {
+                tracing::warn!("failed to get pending block updates stream: {:?}", e);
                 futures::stream::pending().boxed()
             }
         }

--- a/common/tests/test_ingestion_service.rs
+++ b/common/tests/test_ingestion_service.rs
@@ -1,13 +1,20 @@
-use std::sync::Arc;
+use std::{
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 
 use alloy_rpc_types::BlockNumberOrTag;
 use apibara_etcd::EtcdClient;
 use error_stack::{Result, ResultExt};
 use foyer::HybridCacheBuilder;
+use futures::StreamExt;
 use testcontainers::{runners::AsyncRunner, ContainerAsync};
 
 use apibara_dna_common::{
-    chain::BlockInfo,
+    chain::{BlockInfo, PendingBlockInfo},
     file_cache::FileCache,
     fragment,
     ingestion::{
@@ -24,6 +31,8 @@ use apibara_dna_common::{
 use testing::{
     anvil_server_container, AnvilProvider, AnvilProviderExt, AnvilServer, AnvilServerExt,
 };
+use tokio::sync::{mpsc, Mutex};
+use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
 
 async fn get_test_head(provider: &std::sync::Arc<AnvilProvider>) -> apibara_dna_common::Cursor {
@@ -273,6 +282,61 @@ async fn test_ingestion_advances_as_head_changes() {
 
     let ingested = state_client.get_ingested().await.unwrap();
     assert!(ingested.is_some());
+}
+
+#[tokio::test]
+async fn test_ingestion_queues_pending_from_push_update_without_poll_interval() {
+    let (_minio, object_store) = init_minio().await;
+    let (_etcd_server, etcd_client) = init_etcd_server().await;
+    let (_anvil_server, anvil_provider) = init_anvil().await;
+
+    let file_cache = init_file_cache().await;
+    let (_pending_tx, pending_rx) = mpsc::channel(4);
+    let pending_ingest_count = Arc::new(AtomicUsize::new(0));
+
+    let block_ingestion = PendingTestBlockIngestion {
+        provider: anvil_provider,
+        pending_rx: Arc::new(Mutex::new(Some(pending_rx))),
+        pending_ingest_count: pending_ingest_count.clone(),
+    };
+
+    let options = IngestionServiceOptions {
+        pending_refresh_interval: Duration::from_secs(60 * 60),
+        ..Default::default()
+    };
+
+    let mut service = IngestionService::new(
+        block_ingestion,
+        etcd_client,
+        object_store,
+        file_cache,
+        options,
+        IngestionMetrics::default(),
+    );
+
+    let starting_state = service.initialize().await.unwrap();
+    let state = starting_state.take_ingest().unwrap();
+
+    _pending_tx.send(Ok(())).await.unwrap();
+    let ct = CancellationToken::new();
+    let state = service.tick_ingest(state, ct.clone()).await.unwrap();
+    let state = state.take_ingest().unwrap();
+
+    assert_eq!(service.task_queue_len(), 1);
+
+    _pending_tx.send(Ok(())).await.unwrap();
+    let state = service.tick_ingest(state, ct).await.unwrap();
+    let state = state.take_ingest().unwrap();
+
+    assert_eq!(service.task_queue_len(), 1);
+
+    let join_result = service.task_queue_next().await;
+    service
+        .tick_with_task_result(state, join_result)
+        .await
+        .unwrap();
+
+    assert_eq!(pending_ingest_count.load(Ordering::SeqCst), 1);
 }
 
 #[tokio::test]
@@ -806,6 +870,13 @@ struct TestBlockIngestion {
     provider: Arc<AnvilProvider>,
 }
 
+#[derive(Clone)]
+struct PendingTestBlockIngestion {
+    provider: Arc<AnvilProvider>,
+    pending_rx: Arc<Mutex<Option<mpsc::Receiver<Result<(), IngestionError>>>>>,
+    pending_ingest_count: Arc<AtomicUsize>,
+}
+
 impl BlockIngestion for TestBlockIngestion {
     async fn get_head_cursor(&self) -> Result<Cursor, IngestionError> {
         let header = self.provider.get_header(BlockNumberOrTag::Latest).await;
@@ -861,6 +932,97 @@ impl BlockIngestion for TestBlockIngestion {
         };
 
         Ok((info, block))
+    }
+}
+
+impl BlockIngestion for PendingTestBlockIngestion {
+    fn supports_pending(&self) -> bool {
+        true
+    }
+
+    async fn get_head_cursor(&self) -> Result<Cursor, IngestionError> {
+        let header = self.provider.get_header(BlockNumberOrTag::Latest).await;
+        let hash = Hash(header.hash.to_vec());
+        Ok(Cursor::new(header.number, hash))
+    }
+
+    async fn get_finalized_cursor(&self) -> Result<Cursor, IngestionError> {
+        let header = self.provider.get_header(BlockNumberOrTag::Finalized).await;
+        let hash = Hash(header.hash.to_vec());
+        Ok(Cursor::new(header.number, hash))
+    }
+
+    async fn get_block_info_by_number(&self, number: u64) -> Result<BlockInfo, IngestionError> {
+        let Some(header) = self
+            .provider
+            .get_maybe_header(BlockNumberOrTag::Number(number))
+            .await
+        else {
+            return Err(IngestionError::BlockNotFound).attach_printable("missing block");
+        };
+        let hash = Hash(header.hash.to_vec());
+        let parent_hash = Hash(header.parent_hash.to_vec());
+
+        Ok(BlockInfo {
+            number,
+            hash,
+            parent: parent_hash,
+        })
+    }
+
+    async fn ingest_block_by_number(
+        &self,
+        number: u64,
+    ) -> Result<(BlockInfo, fragment::Block), IngestionError> {
+        let info = self.get_block_info_by_number(number).await?;
+        Ok((info, empty_block()))
+    }
+
+    async fn ingest_pending_block(
+        &self,
+        parent: &Cursor,
+        generation: u64,
+    ) -> Result<Option<(PendingBlockInfo, fragment::Block)>, IngestionError> {
+        self.pending_ingest_count.fetch_add(1, Ordering::SeqCst);
+
+        Ok(Some((
+            PendingBlockInfo {
+                number: parent.number + 1,
+                generation,
+                parent: parent.hash.clone(),
+            },
+            empty_block(),
+        )))
+    }
+
+    async fn pending_block_updates_stream(
+        &self,
+    ) -> Result<apibara_dna_common::ingestion::BoxedPendingBlockUpdateStream, IngestionError> {
+        let mut pending_rx = self.pending_rx.lock().await;
+        let Some(rx) = pending_rx.take() else {
+            return Ok(futures::stream::pending().boxed());
+        };
+
+        Ok(ReceiverStream::new(rx).boxed())
+    }
+}
+
+fn empty_block() -> fragment::Block {
+    let header = fragment::HeaderFragment {
+        data: Vec::default(),
+    };
+    let index = fragment::IndexGroupFragment {
+        indexes: Vec::default(),
+    };
+    let join = fragment::JoinGroupFragment {
+        joins: Vec::default(),
+    };
+
+    fragment::Block {
+        header,
+        index,
+        join,
+        body: Vec::default(),
     }
 }
 

--- a/docs/starknet-ws-live-ingestion.md
+++ b/docs/starknet-ws-live-ingestion.md
@@ -1,0 +1,62 @@
+# Starknet WS Live Ingestion
+
+This change adds an opt-in push-first live ingestion plane for Starknet pre-confirmed transaction and receipt data.
+
+## Problem
+
+The existing Starknet pending path polls `getBlockWithReceipts(PRE_CONFIRMED)` and then waits for `getStateUpdate(PRE_CONFIRMED)` before a pending DNA block can be written. Event and receipt-only consumers therefore inherit state update latency even though Starknet websocket subscriptions can deliver the relevant receipt/event payload earlier.
+
+There is also a moving-tag failure mode: by the time DNA polls the `PRE_CONFIRMED` tag, the pushed websocket data may already refer to a block that the tag has moved past. Reducing the polling interval alone does not remove that race and does not make event delivery push-based.
+
+## Architecture
+
+Canonical HTTP ingestion remains the source of truth for:
+
+- Backfill.
+- Accepted and finalized blocks.
+- Reorg reconciliation.
+- State updates, storage diffs, nonces, and contract/class changes.
+- Optional traces.
+
+The new websocket live plane handles optimistic pending data:
+
+- `starknet_subscribeNewTransactionReceipts` with `PRE_CONFIRMED`.
+- `starknet_subscribeNewTransactions` with `PRE_CONFIRMED`.
+
+Receipt and transaction notifications are correlated by `transaction_hash` in `StarknetLiveAssembler`. As soon as receipt/event data is available for the next pending block, DNA can write a pending block fragment without waiting for `getStateUpdate(PRE_CONFIRMED)`. If the transaction body has not arrived yet, receipt/event-only fragments are still emitted.
+
+Accepted/finalized HTTP ingestion later writes canonical blocks and prunes live assembler entries through the accepted block number.
+
+## Configuration
+
+Live ingestion is disabled by default.
+
+Enable it with:
+
+```bash
+STARKNET_WS_URL=ws://...
+STARKNET_WS_LIVE_INGESTION_ENABLED=true
+```
+
+Setting `STARKNET_WS_LIVE_INGESTION_ENABLED=true` also enables the pending stream lane. The existing `STARKNET_INGEST_PRE_CONFIRMED=true` HTTP pending behavior remains available when websocket live ingestion is disabled.
+
+## Benchmark
+
+The benchmark command compares direct Starknet `subscribeEvents` first-seen time against DNA pending stream first-seen time for matching events. The DNA filter includes the matching event and receipt, but not the transaction body, so the measurement targets the receipt/event live path directly.
+
+```bash
+cargo run -p apibara-benchmark -- starknet-live-latency \
+  --direct-ws-url ws://64.34.87.87:9545/ws/rpc/v0_10 \
+  --stream-url http://localhost:7007 \
+  --game-core-address 0x... \
+  --game-event-key 0x... \
+  --adventurer-id 0x...
+```
+
+It prints one CSV-style row per matched event:
+
+```text
+txHash,blockNumber,eventIndex,finality,directSubscribeEventsSeenMs,dnaStreamSeenMs,dnaMinusSubscribeEventsMs
+```
+
+Acceptance target: `p95DnaMinusSubscribeEventsMs <= 500` under normal live conditions.

--- a/starknet/Cargo.toml
+++ b/starknet/Cargo.toml
@@ -42,7 +42,7 @@ time.workspace = true
 tonic.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
-tokio-tungstenite = { version = "0.26.0", features = ["native-tls"] }
+tokio-tungstenite = { version = "0.26.0", features = ["rustls-tls-native-roots"] }
 tokio-util.workspace = true
 tracing.workspace = true
 url.workspace = true

--- a/starknet/src/cli/start.rs
+++ b/starknet/src/cli/start.rs
@@ -34,6 +34,14 @@ pub struct StartCommand {
         default_value = "false"
     )]
     ingest_pre_confirmed: bool,
+
+    /// Ingest pre-confirmed transaction and receipt data from Starknet WebSocket subscriptions.
+    #[arg(
+        long = "starknet.ws-live-ingestion-enabled",
+        env = "STARKNET_WS_LIVE_INGESTION_ENABLED",
+        default_value = "false"
+    )]
+    ws_live_ingestion_enabled: bool,
 }
 
 impl StartCommand {
@@ -41,8 +49,9 @@ impl StartCommand {
         info!("Starting Starknet DNA server");
         let provider = self.rpc.to_starknet_provider()?;
         let starknet_ingestion_options = StarknetBlockIngestionOptions {
-            ingest_pending: self.ingest_pre_confirmed,
+            ingest_pending: self.ingest_pre_confirmed || self.ws_live_ingestion_enabled,
             ingest_traces: self.ingest_traces,
+            live_ingestion_enabled: self.ws_live_ingestion_enabled,
         };
         let starknet_chain =
             StarknetChainSupport::new(provider, self.ws_url, starknet_ingestion_options);

--- a/starknet/src/ingestion.rs
+++ b/starknet/src/ingestion.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use apibara_dna_common::{
     chain::{BlockInfo, PendingBlockInfo},
@@ -7,7 +7,9 @@ use apibara_dna_common::{
         JoinFragment, JoinGroupFragment,
     },
     index::{BitmapIndexBuilder, ScalarValue},
-    ingestion::{BlockIngestion, BoxedNewHeadsStream, IngestionError},
+    ingestion::{
+        BlockIngestion, BoxedNewHeadsStream, BoxedPendingBlockUpdateStream, IngestionError,
+    },
     join::{JoinToManyIndexBuilder, JoinToOneIndexBuilder},
     Cursor, Hash,
 };
@@ -15,6 +17,7 @@ use apibara_dna_protocol::starknet;
 use error_stack::{Report, Result, ResultExt};
 // use futures::StreamExt;
 use prost::Message;
+use tokio::sync::Mutex;
 use tokio_stream::StreamExt as TokioStreamExt;
 use tracing::{info, Instrument};
 
@@ -33,10 +36,11 @@ use crate::{
         RECEIPT_FRAGMENT_NAME, STORAGE_DIFF_FRAGMENT_ID, STORAGE_DIFF_FRAGMENT_NAME,
         TRACE_FRAGMENT_ID, TRACE_FRAGMENT_NAME, TRANSACTION_FRAGMENT_ID, TRANSACTION_FRAGMENT_NAME,
     },
+    live::{LiveAssemblerInsert, StarknetLiveAssembler},
     proto::{convert_block_header, convert_pre_confirmed_block_header, ModelExt},
     provider::{
-        models, BlockExt, BlockId, StarknetProvider, StarknetProviderError,
-        StarknetProviderErrorExt,
+        models, BlockExt, BlockId, StarknetLiveTransactionsStream, StarknetProvider,
+        StarknetProviderError, StarknetProviderErrorExt,
     },
     NewHeadsStream,
 };
@@ -45,12 +49,14 @@ use crate::{
 pub struct StarknetBlockIngestionOptions {
     pub ingest_pending: bool,
     pub ingest_traces: bool,
+    pub live_ingestion_enabled: bool,
 }
 
 pub struct StarknetBlockIngestion {
     provider: StarknetProvider,
     ws_url: Option<String>,
     options: StarknetBlockIngestionOptions,
+    live_assembler: Arc<Mutex<StarknetLiveAssembler>>,
 }
 
 impl StarknetBlockIngestion {
@@ -63,14 +69,15 @@ impl StarknetBlockIngestion {
             provider,
             ws_url,
             options,
+            live_assembler: Arc::new(Mutex::new(StarknetLiveAssembler::new())),
         }
     }
 }
 
-struct BlockIngestionResult {
-    body: Vec<BodyFragment>,
-    index: Vec<IndexFragment>,
-    join: Vec<JoinFragment>,
+pub(crate) struct BlockIngestionResult {
+    pub(crate) body: Vec<BodyFragment>,
+    pub(crate) index: Vec<IndexFragment>,
+    pub(crate) join: Vec<JoinFragment>,
 }
 
 impl BlockIngestion for StarknetBlockIngestion {
@@ -103,6 +110,61 @@ impl BlockIngestion for StarknetBlockIngestion {
         {
             use futures::StreamExt;
             Ok(stream.boxed())
+        }
+    }
+
+    #[tracing::instrument("starknet_pending_block_updates_stream", skip_all, err(Debug))]
+    async fn pending_block_updates_stream(
+        &self,
+    ) -> Result<BoxedPendingBlockUpdateStream, IngestionError> {
+        if !self.options.ingest_pending || !self.options.live_ingestion_enabled {
+            use futures::StreamExt;
+            return Ok(futures::stream::pending().boxed());
+        }
+
+        let Some(url) = self.ws_url.as_ref() else {
+            use futures::StreamExt;
+            return Ok(futures::stream::pending().boxed());
+        };
+
+        info!("subscribing to live starknet transaction receipts");
+
+        let assembler = self.live_assembler.clone();
+        let stream = StarknetLiveTransactionsStream::connect(url)
+            .await
+            .change_context(IngestionError::RpcRequest)
+            .attach_printable("failed to connect to starknet live ws")?
+            .timeout(Duration::from_secs(60));
+
+        {
+            use futures::StreamExt;
+
+            let stream = futures::StreamExt::then(stream, move |message| {
+                let assembler = assembler.clone();
+                async move {
+                    match message {
+                        Ok(Ok(message)) => {
+                            let mut assembler = assembler.lock().await;
+                            let insert = assembler.push_message(message);
+                            if insert == LiveAssemblerInsert::Duplicate
+                                || assembler.pending_block_numbers().is_empty()
+                            {
+                                None
+                            } else {
+                                Some(Ok(()))
+                            }
+                        }
+                        Ok(Err(err)) => Some(Err(err).change_context(IngestionError::RpcRequest)),
+                        Err(err) => Some(
+                            Err(err)
+                                .change_context(StarknetProviderError::Timeout)
+                                .change_context(IngestionError::RpcRequest),
+                        ),
+                    }
+                }
+            });
+
+            Ok(futures::StreamExt::filter_map(stream, |message| async move { message }).boxed())
         }
     }
 
@@ -181,6 +243,24 @@ impl BlockIngestion for StarknetBlockIngestion {
         parent: &Cursor,
         generation: u64,
     ) -> Result<Option<(PendingBlockInfo, Block)>, IngestionError> {
+        if self.options.live_ingestion_enabled {
+            let number = parent.number + 1;
+            let live_block = {
+                let assembler = self.live_assembler.lock().await;
+                assembler.build_pending_block(number)?
+            };
+
+            if let Some(live_block) = live_block {
+                let block_info = PendingBlockInfo {
+                    number: live_block.block_number,
+                    generation,
+                    parent: parent.hash.clone(),
+                };
+
+                return Ok(Some((block_info, live_block.block)));
+            }
+        }
+
         let block_id = BlockId::Pending;
 
         let block = match self.provider.get_block_with_receipts(&block_id).await {
@@ -411,6 +491,10 @@ impl BlockIngestion for StarknetBlockIngestion {
             })
         })?;
 
+        if self.options.live_ingestion_enabled {
+            self.live_assembler.lock().await.prune_through_block(number);
+        }
+
         Ok((block_info, block))
     }
 }
@@ -421,14 +505,44 @@ impl Clone for StarknetBlockIngestion {
             provider: self.provider.clone(),
             ws_url: self.ws_url.clone(),
             options: self.options.clone(),
+            live_assembler: self.live_assembler.clone(),
         }
     }
 }
 
-fn collect_block_body_and_index(
+pub(crate) fn collect_block_body_and_index(
     transactions: &[models::TransactionWithReceipt],
     transaction_traces: &[models::TransactionTraceWithHash],
 ) -> Result<BlockIngestionResult, IngestionError> {
+    let transaction_contents = transactions
+        .iter()
+        .map(|transaction| &transaction.transaction)
+        .collect::<Vec<_>>();
+    let receipts = transactions
+        .iter()
+        .map(|transaction| &transaction.receipt)
+        .collect::<Vec<_>>();
+
+    collect_block_records_body_and_index(&receipts, Some(&transaction_contents), transaction_traces)
+}
+
+pub(crate) fn collect_receipts_body_and_index(
+    receipts: &[models::TransactionReceipt],
+) -> Result<BlockIngestionResult, IngestionError> {
+    let receipts = receipts.iter().collect::<Vec<_>>();
+
+    collect_block_records_body_and_index(&receipts, None, &[])
+}
+
+fn collect_block_records_body_and_index(
+    receipts: &[&models::TransactionReceipt],
+    transactions: Option<&[&models::TransactionContent]>,
+    transaction_traces: &[models::TransactionTraceWithHash],
+) -> Result<BlockIngestionResult, IngestionError> {
+    if let Some(transactions) = transactions {
+        debug_assert_eq!(receipts.len(), transactions.len());
+    }
+
     let mut block_transactions = Vec::new();
     let mut block_receipts = Vec::new();
     let mut block_events = Vec::new();
@@ -475,19 +589,16 @@ fn collect_block_body_and_index(
         block_traces.push(trace);
     }
 
-    for (transaction_index, transaction_with_receipt) in transactions.iter().enumerate() {
+    for (transaction_index, receipt) in receipts.iter().enumerate() {
         let transaction_index = transaction_index as u32;
-        let transaction_hash = transaction_with_receipt
-            .receipt
-            .transaction_hash()
-            .to_proto();
+        let transaction_hash = receipt.transaction_hash().to_proto();
 
-        let transaction_status = match transaction_with_receipt.receipt.execution_result() {
+        let transaction_status = match receipt.execution_result() {
             models::ExecutionResult::Succeeded => starknet::TransactionStatus::Succeeded,
             models::ExecutionResult::Reverted { .. } => starknet::TransactionStatus::Reverted,
         };
 
-        let events = match &transaction_with_receipt.receipt {
+        let events = match receipt {
             models::TransactionReceipt::Invoke(rx) => &rx.events,
             models::TransactionReceipt::L1Handler(rx) => &rx.events,
             models::TransactionReceipt::Declare(rx) => &rx.events,
@@ -507,8 +618,10 @@ fn collect_block_body_and_index(
             event.transaction_status = transaction_status as i32;
             event.event_index_in_transaction = event_index_in_transaction as u32;
 
-            join_transaction_to_events.insert(transaction_index, event.event_index);
-            join_event_to_transaction.insert(event.event_index, transaction_index);
+            if transactions.is_some() {
+                join_transaction_to_events.insert(transaction_index, event.event_index);
+                join_event_to_transaction.insert(event.event_index, transaction_index);
+            }
             join_event_to_receipt.insert(event.event_index, transaction_index);
             if !block_traces.is_empty() {
                 join_event_to_trace.insert(event.event_index, transaction_index);
@@ -549,7 +662,7 @@ fn collect_block_body_and_index(
             block_events.push(event);
         }
 
-        let messages = match &transaction_with_receipt.receipt {
+        let messages = match receipt {
             models::TransactionReceipt::Invoke(rx) => &rx.messages_sent,
             models::TransactionReceipt::L1Handler(rx) => &rx.messages_sent,
             models::TransactionReceipt::Declare(rx) => &rx.messages_sent,
@@ -566,8 +679,10 @@ fn collect_block_body_and_index(
             message.transaction_status = transaction_status as i32;
             message.message_index_in_transaction = message_index_in_transaction as u32;
 
-            join_transaction_to_messages.insert(transaction_index, message.message_index);
-            join_message_to_transaction.insert(message.message_index, transaction_index);
+            if transactions.is_some() {
+                join_transaction_to_messages.insert(transaction_index, message.message_index);
+                join_message_to_transaction.insert(message.message_index, transaction_index);
+            }
             join_message_to_receipt.insert(message.message_index, transaction_index);
             if !block_traces.is_empty() {
                 join_message_to_trace.insert(message.message_index, transaction_index);
@@ -616,45 +731,51 @@ fn collect_block_body_and_index(
             }
         }
 
-        let mut transaction = transaction_with_receipt.transaction.to_proto();
-        set_transaction_meta(
-            &mut transaction,
-            transaction_hash,
-            transaction_index,
-            transaction_status,
-        );
+        if let Some(transaction_content) =
+            transactions.and_then(|transactions| transactions.get(transaction_index as usize))
+        {
+            let mut transaction = transaction_content.to_proto();
+            set_transaction_meta(
+                &mut transaction,
+                transaction_hash,
+                transaction_index,
+                transaction_status,
+            );
 
-        use starknet::transaction::Transaction;
-        let transaction_type = match transaction.transaction {
-            Some(Transaction::InvokeV0(_)) => Some(TransactionType::InvokeV0),
-            Some(Transaction::InvokeV1(_)) => Some(TransactionType::InvokeV1),
-            Some(Transaction::InvokeV3(_)) => Some(TransactionType::InvokeV3),
-            Some(Transaction::Deploy(_)) => Some(TransactionType::Deploy),
-            Some(Transaction::DeclareV0(_)) => Some(TransactionType::DeclareV0),
-            Some(Transaction::DeclareV1(_)) => Some(TransactionType::DeclareV1),
-            Some(Transaction::DeclareV2(_)) => Some(TransactionType::DeclareV2),
-            Some(Transaction::DeclareV3(_)) => Some(TransactionType::DeclareV3),
-            Some(Transaction::L1Handler(_)) => Some(TransactionType::L1Handler),
-            Some(Transaction::DeployAccountV1(_)) => Some(TransactionType::DeployAccountV1),
-            Some(Transaction::DeployAccountV3(_)) => Some(TransactionType::DeployAccountV3),
-            None => None,
-        };
+            use starknet::transaction::Transaction;
+            let transaction_type = match transaction.transaction {
+                Some(Transaction::InvokeV0(_)) => Some(TransactionType::InvokeV0),
+                Some(Transaction::InvokeV1(_)) => Some(TransactionType::InvokeV1),
+                Some(Transaction::InvokeV3(_)) => Some(TransactionType::InvokeV3),
+                Some(Transaction::Deploy(_)) => Some(TransactionType::Deploy),
+                Some(Transaction::DeclareV0(_)) => Some(TransactionType::DeclareV0),
+                Some(Transaction::DeclareV1(_)) => Some(TransactionType::DeclareV1),
+                Some(Transaction::DeclareV2(_)) => Some(TransactionType::DeclareV2),
+                Some(Transaction::DeclareV3(_)) => Some(TransactionType::DeclareV3),
+                Some(Transaction::L1Handler(_)) => Some(TransactionType::L1Handler),
+                Some(Transaction::DeployAccountV1(_)) => Some(TransactionType::DeployAccountV1),
+                Some(Transaction::DeployAccountV3(_)) => Some(TransactionType::DeployAccountV3),
+                None => None,
+            };
 
-        if let Some(transaction_type) = transaction_type {
-            index_transaction_by_type.insert(transaction_type.to_scalar_value(), transaction_index);
+            if let Some(transaction_type) = transaction_type {
+                index_transaction_by_type
+                    .insert(transaction_type.to_scalar_value(), transaction_index);
+            }
+
+            index_transaction_by_status.insert(
+                ScalarValue::Int32(transaction_status as i32),
+                transaction_index,
+            );
+
+            join_transaction_to_receipt.insert(transaction_index, transaction_index);
+
+            block_transactions.push(transaction);
         }
 
-        index_transaction_by_status.insert(
-            ScalarValue::Int32(transaction_status as i32),
-            transaction_index,
-        );
-
-        let mut receipt = transaction_with_receipt.receipt.to_proto();
+        let mut receipt = receipt.to_proto();
         set_receipt_transaction_index(&mut receipt, transaction_index);
 
-        join_transaction_to_receipt.insert(transaction_index, transaction_index);
-
-        block_transactions.push(transaction);
         block_receipts.push(receipt);
     }
 
@@ -1010,7 +1131,7 @@ fn collect_block_body_and_index(
     })
 }
 
-fn collect_state_update_body_and_index(
+pub(crate) fn collect_state_update_body_and_index(
     state_diff: &models::StateDiff,
 ) -> Result<BlockIngestionResult, IngestionError> {
     let mut block_storage_diffs = Vec::new();

--- a/starknet/src/lib.rs
+++ b/starknet/src/lib.rs
@@ -11,13 +11,18 @@ use ingestion::StarknetBlockIngestion;
 use provider::StarknetProvider;
 
 pub use ingestion::StarknetBlockIngestionOptions;
-pub use provider::{NewHeadMessage, NewHeadsStream};
+pub use live::{LiveAssemblerInsert, LivePendingBlock, StarknetLiveAssembler};
+pub use provider::{
+    NewHeadMessage, NewHeadsStream, NewTransactionMessage, NewTransactionReceiptMessage,
+    StarknetLiveMessage, StarknetLiveTransactionsStream,
+};
 
 pub mod cli;
 pub mod error;
 pub mod filter;
 pub mod fragment;
 pub mod ingestion;
+pub mod live;
 pub mod proto;
 pub mod provider;
 

--- a/starknet/src/live.rs
+++ b/starknet/src/live.rs
@@ -1,0 +1,455 @@
+use std::collections::HashMap;
+
+use apibara_dna_common::fragment::{Block, HeaderFragment, IndexGroupFragment, JoinGroupFragment};
+use apibara_dna_common::ingestion::IngestionError;
+use apibara_dna_protocol::starknet;
+use error_stack::Result;
+use prost::Message;
+
+use crate::{
+    ingestion::{
+        collect_block_body_and_index, collect_receipts_body_and_index,
+        collect_state_update_body_and_index,
+    },
+    provider::{models, NewTransactionMessage, NewTransactionReceiptMessage, StarknetLiveMessage},
+};
+
+/// Result of inserting a live transaction or receipt into the assembler.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LiveAssemblerInsert {
+    Inserted,
+    Updated,
+    Duplicate,
+}
+
+/// A pending block fragment assembled from live Starknet websocket data.
+#[derive(Debug)]
+pub struct LivePendingBlock {
+    pub block_number: u64,
+    pub transaction_hashes: Vec<models::FieldElement>,
+    pub block: Block,
+}
+
+/// Correlates live Starknet transaction and receipt websocket notifications.
+#[derive(Debug, Default)]
+pub struct StarknetLiveAssembler {
+    entries: HashMap<models::FieldElement, LiveEntry>,
+    next_arrival_order: u64,
+}
+
+#[derive(Debug, Clone)]
+struct LiveEntry {
+    transaction: Option<models::TransactionWithL2Status>,
+    receipt: Option<models::TransactionReceiptWithBlockInfo>,
+    block_number: Option<u64>,
+    transaction_index: Option<u64>,
+    arrival_order: u64,
+}
+
+impl StarknetLiveAssembler {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn push_message(&mut self, message: StarknetLiveMessage) -> LiveAssemblerInsert {
+        match message {
+            StarknetLiveMessage::Transaction(message) => self.push_transaction(message),
+            StarknetLiveMessage::Receipt(message) => self.push_receipt(message),
+        }
+    }
+
+    pub fn push_transaction(&mut self, message: NewTransactionMessage) -> LiveAssemblerInsert {
+        self.push_transaction_with_meta(
+            message.transaction,
+            message.block_number,
+            message.transaction_index,
+        )
+    }
+
+    pub fn push_transaction_with_meta(
+        &mut self,
+        transaction: models::TransactionWithL2Status,
+        block_number: Option<u64>,
+        transaction_index: Option<u64>,
+    ) -> LiveAssemblerInsert {
+        let transaction_hash = *transaction.txn.transaction_hash();
+        let was_new = !self.entries.contains_key(&transaction_hash);
+        let entry = self.entry_mut(transaction_hash);
+
+        let mut changed = entry.merge_position(block_number, transaction_index);
+        if entry.transaction.is_none() {
+            entry.transaction = Some(transaction);
+            changed = true;
+        }
+
+        insertion_result(was_new, changed)
+    }
+
+    pub fn push_receipt(&mut self, message: NewTransactionReceiptMessage) -> LiveAssemblerInsert {
+        self.push_receipt_with_meta(message.receipt, message.transaction_index)
+    }
+
+    pub fn push_receipt_with_meta(
+        &mut self,
+        receipt: models::TransactionReceiptWithBlockInfo,
+        transaction_index: Option<u64>,
+    ) -> LiveAssemblerInsert {
+        let transaction_hash = *receipt.receipt.transaction_hash();
+        let block_number = Some(receipt.block.block_number());
+        let was_new = !self.entries.contains_key(&transaction_hash);
+        let entry = self.entry_mut(transaction_hash);
+
+        let mut changed = entry.merge_position(block_number, transaction_index);
+        if entry.receipt.is_none() {
+            entry.receipt = Some(receipt);
+            changed = true;
+        }
+
+        insertion_result(was_new, changed)
+    }
+
+    pub fn pending_block_numbers(&self) -> Vec<u64> {
+        let mut block_numbers = self
+            .entries
+            .values()
+            .filter_map(|entry| {
+                entry
+                    .receipt
+                    .as_ref()
+                    .map(|receipt| receipt.block.block_number())
+            })
+            .collect::<Vec<_>>();
+        block_numbers.sort_unstable();
+        block_numbers.dedup();
+        block_numbers
+    }
+
+    pub fn prune_through_block(&mut self, block_number: u64) {
+        self.entries.retain(|_, entry| {
+            entry
+                .receipt
+                .as_ref()
+                .map(|receipt| receipt.block.block_number() > block_number)
+                .unwrap_or(true)
+        });
+    }
+
+    pub fn build_pending_block(
+        &self,
+        block_number: u64,
+    ) -> Result<Option<LivePendingBlock>, IngestionError> {
+        let entries = self.ordered_entries(block_number);
+        if entries.is_empty() {
+            return Ok(None);
+        }
+
+        let transaction_hashes = entries
+            .iter()
+            .map(|entry| *entry.receipt.as_ref().unwrap().receipt.transaction_hash())
+            .collect::<Vec<_>>();
+
+        let body_ingestion_result = if entries.iter().all(|entry| entry.transaction.is_some()) {
+            let transactions = entries
+                .iter()
+                .map(|entry| {
+                    let transaction = entry.transaction.as_ref().unwrap().clone();
+                    let receipt = entry.receipt.as_ref().unwrap().receipt.clone();
+                    models::TransactionWithReceipt {
+                        transaction: transaction.txn.into(),
+                        receipt,
+                    }
+                })
+                .collect::<Vec<_>>();
+
+            collect_block_body_and_index(&transactions, &[])?
+        } else {
+            let receipts = entries
+                .iter()
+                .map(|entry| entry.receipt.as_ref().unwrap().receipt.clone())
+                .collect::<Vec<_>>();
+
+            collect_receipts_body_and_index(&receipts)?
+        };
+
+        let state_update_ingestion_result =
+            collect_state_update_body_and_index(&empty_state_diff())?;
+
+        let mut body_fragments = body_ingestion_result.body;
+        let mut index_fragments = body_ingestion_result.index;
+        let mut join_fragments = body_ingestion_result.join;
+
+        body_fragments.extend(state_update_ingestion_result.body);
+        index_fragments.extend(state_update_ingestion_result.index);
+        join_fragments.extend(state_update_ingestion_result.join);
+
+        let header = starknet::BlockHeader {
+            block_number,
+            ..Default::default()
+        };
+
+        Ok(Some(LivePendingBlock {
+            block_number,
+            transaction_hashes,
+            block: Block {
+                header: HeaderFragment {
+                    data: header.encode_to_vec(),
+                },
+                index: IndexGroupFragment {
+                    indexes: index_fragments,
+                },
+                body: body_fragments,
+                join: JoinGroupFragment {
+                    joins: join_fragments,
+                },
+            },
+        }))
+    }
+
+    fn entry_mut(&mut self, transaction_hash: models::FieldElement) -> &mut LiveEntry {
+        if !self.entries.contains_key(&transaction_hash) {
+            let arrival_order = self.next_arrival_order;
+            self.next_arrival_order += 1;
+            self.entries.insert(
+                transaction_hash,
+                LiveEntry {
+                    transaction: None,
+                    receipt: None,
+                    block_number: None,
+                    transaction_index: None,
+                    arrival_order,
+                },
+            );
+        }
+
+        self.entries.get_mut(&transaction_hash).unwrap()
+    }
+
+    fn ordered_entries(&self, block_number: u64) -> Vec<&LiveEntry> {
+        let mut entries = self
+            .entries
+            .values()
+            .filter(|entry| {
+                entry
+                    .receipt
+                    .as_ref()
+                    .is_some_and(|receipt| receipt.block.block_number() == block_number)
+            })
+            .collect::<Vec<_>>();
+
+        entries.sort_by_key(|entry| entry.order_key());
+
+        entries
+    }
+}
+
+impl LiveEntry {
+    fn merge_position(
+        &mut self,
+        block_number: Option<u64>,
+        transaction_index: Option<u64>,
+    ) -> bool {
+        let mut changed = false;
+
+        if self.block_number.is_none() && block_number.is_some() {
+            self.block_number = block_number;
+            changed = true;
+        }
+
+        if self.transaction_index.is_none() && transaction_index.is_some() {
+            self.transaction_index = transaction_index;
+            changed = true;
+        }
+
+        changed
+    }
+
+    fn position(&self) -> Option<(u64, u64)> {
+        self.block_number.zip(self.transaction_index)
+    }
+
+    fn order_key(&self) -> (u8, u64, u64, u64) {
+        match self.position() {
+            Some((block_number, transaction_index)) => {
+                (0, block_number, transaction_index, self.arrival_order)
+            }
+            None => (1, 0, 0, self.arrival_order),
+        }
+    }
+}
+
+fn insertion_result(was_uncorrelated: bool, changed: bool) -> LiveAssemblerInsert {
+    match (was_uncorrelated, changed) {
+        (_, false) => LiveAssemblerInsert::Duplicate,
+        (true, true) => LiveAssemblerInsert::Inserted,
+        (false, true) => LiveAssemblerInsert::Updated,
+    }
+}
+
+fn empty_state_diff() -> models::StateDiff {
+    models::StateDiff {
+        storage_diffs: Vec::new(),
+        deprecated_declared_classes: Vec::new(),
+        declared_classes: Vec::new(),
+        migrated_compiled_classes: None,
+        deployed_contracts: Vec::new(),
+        replaced_classes: Vec::new(),
+        nonces: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fragment::{RECEIPT_FRAGMENT_ID, TRANSACTION_FRAGMENT_ID};
+    use starknet_rust::core::types::{
+        ExecutionResources, FeePayment, InvokeTransaction, InvokeTransactionReceipt,
+        InvokeTransactionV1, PriceUnit, TransactionFinalityStatus,
+    };
+
+    fn felt(value: u64) -> models::FieldElement {
+        models::FieldElement::from_hex(&format!("0x{value:x}")).unwrap()
+    }
+
+    fn transaction(hash: u64) -> models::TransactionWithL2Status {
+        models::TransactionWithL2Status {
+            txn: models::Transaction::Invoke(InvokeTransaction::V1(InvokeTransactionV1 {
+                transaction_hash: felt(hash),
+                sender_address: felt(1),
+                calldata: Vec::new(),
+                max_fee: felt(0),
+                signature: Vec::new(),
+                nonce: felt(0),
+            })),
+            finality_status: models::L2TransactionStatus::PreConfirmed,
+        }
+    }
+
+    fn receipt(hash: u64, block_number: u64) -> models::TransactionReceiptWithBlockInfo {
+        models::TransactionReceiptWithBlockInfo {
+            receipt: models::TransactionReceipt::Invoke(InvokeTransactionReceipt {
+                transaction_hash: felt(hash),
+                actual_fee: FeePayment {
+                    amount: felt(0),
+                    unit: PriceUnit::Fri,
+                },
+                finality_status: TransactionFinalityStatus::PreConfirmed,
+                messages_sent: Vec::new(),
+                events: Vec::new(),
+                execution_resources: ExecutionResources {
+                    l1_gas: 0,
+                    l1_data_gas: 0,
+                    l2_gas: 0,
+                },
+                execution_result: models::ExecutionResult::Succeeded,
+            }),
+            block: models::ReceiptBlock::PreConfirmed { block_number },
+        }
+    }
+
+    fn body_fragment(
+        block: &Block,
+        fragment_id: u8,
+    ) -> &apibara_dna_common::fragment::BodyFragment {
+        block
+            .body
+            .iter()
+            .find(|fragment| fragment.fragment_id == fragment_id)
+            .unwrap()
+    }
+
+    fn receipt_hashes(block: &Block) -> Vec<models::FieldElement> {
+        body_fragment(block, RECEIPT_FRAGMENT_ID)
+            .data
+            .iter()
+            .map(|data| {
+                let receipt = starknet::TransactionReceipt::decode(data.as_slice()).unwrap();
+                let hash = receipt.meta.unwrap().transaction_hash.unwrap();
+                models::FieldElement::from_bytes_be_slice(hash.to_bytes().as_slice())
+            })
+            .collect()
+    }
+
+    #[test]
+    fn correlates_transaction_and_receipt() {
+        let mut assembler = StarknetLiveAssembler::new();
+
+        assert_eq!(
+            assembler.push_transaction_with_meta(transaction(1), None, None),
+            LiveAssemblerInsert::Inserted
+        );
+        assert_eq!(
+            assembler.push_receipt_with_meta(receipt(1, 10), Some(0)),
+            LiveAssemblerInsert::Updated
+        );
+
+        let block = assembler.build_pending_block(10).unwrap().unwrap().block;
+        assert_eq!(body_fragment(&block, TRANSACTION_FRAGMENT_ID).data.len(), 1);
+        assert_eq!(body_fragment(&block, RECEIPT_FRAGMENT_ID).data.len(), 1);
+    }
+
+    #[test]
+    fn emits_receipt_only_block() {
+        let mut assembler = StarknetLiveAssembler::new();
+
+        assert_eq!(
+            assembler.push_receipt_with_meta(receipt(1, 10), None),
+            LiveAssemblerInsert::Inserted
+        );
+
+        let pending = assembler.build_pending_block(10).unwrap().unwrap();
+        assert_eq!(pending.block_number, 10);
+        assert_eq!(
+            body_fragment(&pending.block, TRANSACTION_FRAGMENT_ID)
+                .data
+                .len(),
+            0
+        );
+        assert_eq!(
+            body_fragment(&pending.block, RECEIPT_FRAGMENT_ID)
+                .data
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn ignores_duplicate_receipts() {
+        let mut assembler = StarknetLiveAssembler::new();
+
+        assert_eq!(
+            assembler.push_receipt_with_meta(receipt(1, 10), Some(0)),
+            LiveAssemblerInsert::Inserted
+        );
+        assert_eq!(
+            assembler.push_receipt_with_meta(receipt(1, 10), Some(0)),
+            LiveAssemblerInsert::Duplicate
+        );
+
+        let block = assembler.build_pending_block(10).unwrap().unwrap().block;
+        assert_eq!(body_fragment(&block, RECEIPT_FRAGMENT_ID).data.len(), 1);
+    }
+
+    #[test]
+    fn orders_by_block_transaction_index_when_present() {
+        let mut assembler = StarknetLiveAssembler::new();
+
+        assembler.push_receipt_with_meta(receipt(12, 10), Some(2));
+        assembler.push_receipt_with_meta(receipt(10, 10), Some(0));
+        assembler.push_receipt_with_meta(receipt(11, 10), Some(1));
+
+        let block = assembler.build_pending_block(10).unwrap().unwrap().block;
+        assert_eq!(receipt_hashes(&block), vec![felt(10), felt(11), felt(12)]);
+    }
+
+    #[test]
+    fn falls_back_to_arrival_order_without_transaction_index() {
+        let mut assembler = StarknetLiveAssembler::new();
+
+        assembler.push_receipt_with_meta(receipt(12, 10), None);
+        assembler.push_receipt_with_meta(receipt(10, 10), None);
+        assembler.push_receipt_with_meta(receipt(11, 10), None);
+
+        let block = assembler.build_pending_block(10).unwrap().unwrap().block;
+        assert_eq!(receipt_hashes(&block), vec![felt(12), felt(10), felt(11)]);
+    }
+}

--- a/starknet/src/provider/mod.rs
+++ b/starknet/src/provider/mod.rs
@@ -7,4 +7,7 @@ pub use self::http::{
     StarknetProviderOptions,
 };
 pub use self::models::BlockExt;
-pub use self::ws::{NewHeadMessage, NewHeadsStream};
+pub use self::ws::{
+    NewHeadMessage, NewHeadsStream, NewTransactionMessage, NewTransactionReceiptMessage,
+    StarknetLiveMessage, StarknetLiveTransactionsStream,
+};

--- a/starknet/src/provider/models.rs
+++ b/starknet/src/provider/models.rs
@@ -11,12 +11,13 @@ pub use starknet_rust::core::types::{
     InvokeTransactionContent, InvokeTransactionReceipt, InvokeTransactionTrace,
     InvokeTransactionV0Content, InvokeTransactionV1Content, InvokeTransactionV3Content,
     L1DataAvailabilityMode, L1HandlerTransactionContent, L1HandlerTransactionReceipt,
-    L1HandlerTransactionTrace, MaybePreConfirmedBlockWithReceipts,
+    L1HandlerTransactionTrace, L2TransactionStatus, MaybePreConfirmedBlockWithReceipts,
     MaybePreConfirmedBlockWithTxHashes, MaybePreConfirmedStateUpdate, MsgToL1, NonceUpdate,
-    PreConfirmedBlockWithReceipts, PreConfirmedStateUpdate, PriceUnit, ReplacedClassItem,
-    ResourceBounds, ResourceBoundsMapping, ResourcePrice, StateDiff, StateUpdate, StorageEntry,
-    TraceBlockTransactionsResult, TransactionContent, TransactionReceipt, TransactionTrace,
-    TransactionTraceWithHash, TransactionWithReceipt,
+    PreConfirmedBlockWithReceipts, PreConfirmedStateUpdate, PriceUnit, ReceiptBlock,
+    ReplacedClassItem, ResourceBounds, ResourceBoundsMapping, ResourcePrice, StateDiff,
+    StateUpdate, StorageEntry, TraceBlockTransactionsResult, Transaction, TransactionContent,
+    TransactionFinalityStatus, TransactionReceipt, TransactionReceiptWithBlockInfo,
+    TransactionTrace, TransactionTraceWithHash, TransactionWithL2Status, TransactionWithReceipt,
 };
 
 pub trait BlockExt {

--- a/starknet/src/provider/ws.rs
+++ b/starknet/src/provider/ws.rs
@@ -5,7 +5,15 @@ use apibara_dna_common::{Cursor, Hash};
 use error_stack::{Result, ResultExt};
 use futures::stream::SplitStream;
 use futures::{SinkExt, Stream, StreamExt};
-use starknet_rust::core::types::ConfirmedBlockId;
+use starknet_rust::core::types::requests::{
+    SubscribeNewTransactionReceiptsRequest as StarknetSubscribeNewTransactionReceiptsRequest,
+    SubscribeNewTransactionsRequest as StarknetSubscribeNewTransactionsRequest,
+    SubscriptionNewTransactionReceiptsRequest, SubscriptionNewTransactionRequest,
+};
+use starknet_rust::core::types::{
+    ConfirmedBlockId, L2TransactionFinalityStatus, L2TransactionStatus,
+    TransactionReceiptWithBlockInfo, TransactionWithL2Status,
+};
 use tokio::net::TcpStream;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
@@ -24,9 +32,42 @@ pub struct NewHeadsStream {
     inner: SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>,
 }
 
+/// A new transaction receipt received from a Starknet websocket subscription.
+#[derive(Debug, Clone)]
+pub struct NewTransactionReceiptMessage {
+    pub receipt: TransactionReceiptWithBlockInfo,
+    pub transaction_index: Option<u64>,
+}
+
+/// A new transaction received from a Starknet websocket subscription.
+#[derive(Debug, Clone)]
+pub struct NewTransactionMessage {
+    pub transaction: TransactionWithL2Status,
+    pub block_number: Option<u64>,
+    pub transaction_index: Option<u64>,
+}
+
+/// A live Starknet transaction or receipt websocket notification.
+#[derive(Debug, Clone)]
+pub enum StarknetLiveMessage {
+    Transaction(NewTransactionMessage),
+    Receipt(NewTransactionReceiptMessage),
+}
+
+/// A stream subscribed to Starknet pre-confirmed transaction bodies and receipts.
+pub struct StarknetLiveTransactionsStream {
+    inner: SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>,
+}
+
 #[derive(Debug)]
 struct SubscribeRequest {
     block_id: ConfirmedBlockId,
+}
+
+#[derive(Debug)]
+enum LiveSubscribeRequest {
+    NewTransactionReceipts(StarknetSubscribeNewTransactionReceiptsRequest),
+    NewTransactions(StarknetSubscribeNewTransactionsRequest),
 }
 
 impl NewHeadsStream {
@@ -52,6 +93,47 @@ impl NewHeadsStream {
             .await
             .change_context(StarknetProviderError::Request)
             .attach_printable("failed to send subscribe request")?;
+
+        Ok(Self { inner: read })
+    }
+}
+
+impl StarknetLiveTransactionsStream {
+    /// Creates a new [`StarknetLiveTransactionsStream`] from a websocket URL.
+    pub async fn connect(url: &str) -> Result<Self, StarknetProviderError> {
+        let (ws_stream, _) = tokio_tungstenite::connect_async(url)
+            .await
+            .change_context(StarknetProviderError::Request)
+            .attach_printable("failed to connect to ws stream")?;
+
+        let (mut write, read) = ws_stream.split();
+
+        write
+            .send(
+                LiveSubscribeRequest::NewTransactionReceipts(
+                    StarknetSubscribeNewTransactionReceiptsRequest {
+                        finality_status: Some(vec![L2TransactionFinalityStatus::PreConfirmed]),
+                        sender_address: None,
+                    },
+                )
+                .into(),
+            )
+            .await
+            .change_context(StarknetProviderError::Request)
+            .attach_printable("failed to send transaction receipt subscribe request")?;
+
+        write
+            .send(
+                LiveSubscribeRequest::NewTransactions(StarknetSubscribeNewTransactionsRequest {
+                    finality_status: Some(vec![L2TransactionStatus::PreConfirmed]),
+                    sender_address: None,
+                    tags: None,
+                })
+                .into(),
+            )
+            .await
+            .change_context(StarknetProviderError::Request)
+            .attach_printable("failed to send transaction subscribe request")?;
 
         Ok(Self { inner: read })
     }
@@ -105,6 +187,67 @@ impl NewHeadMessage {
     }
 }
 
+impl StarknetLiveMessage {
+    pub fn try_from_message(msg: Message) -> Result<Option<Self>, StarknetProviderError> {
+        #[derive(Debug, serde::Deserialize)]
+        struct WsMessage {
+            method: Option<String>,
+            params: Option<serde_json::Value>,
+            error: Option<serde_json::Value>,
+        }
+
+        let Message::Text(text) = msg else {
+            return Ok(None);
+        };
+
+        let msg: WsMessage = serde_json::from_str(&text)
+            .change_context(StarknetProviderError::Request)
+            .attach_printable("failed to parse websocket message as json")?;
+
+        if let Some(error) = msg.error {
+            return Err(StarknetProviderError::Request)
+                .attach_printable_lazy(|| format!("websocket json-rpc error: {error}"));
+        }
+
+        let Some(method) = msg.method.as_deref() else {
+            return Ok(None);
+        };
+
+        let Some(params) = msg.params else {
+            return Ok(None);
+        };
+
+        match method {
+            "starknet_subscriptionNewTransactionReceipts" => {
+                let transaction_index = extract_result_u64(&params, "transaction_index");
+                let update: SubscriptionNewTransactionReceiptsRequest =
+                    serde_json::from_value(params)
+                        .change_context(StarknetProviderError::Request)
+                        .attach_printable("failed to parse transaction receipt notification")?;
+
+                Ok(Some(Self::Receipt(NewTransactionReceiptMessage {
+                    receipt: update.result,
+                    transaction_index,
+                })))
+            }
+            "starknet_subscriptionNewTransaction" => {
+                let block_number = extract_result_u64(&params, "block_number");
+                let transaction_index = extract_result_u64(&params, "transaction_index");
+                let update: SubscriptionNewTransactionRequest = serde_json::from_value(params)
+                    .change_context(StarknetProviderError::Request)
+                    .attach_printable("failed to parse transaction notification")?;
+
+                Ok(Some(Self::Transaction(NewTransactionMessage {
+                    transaction: update.result,
+                    block_number,
+                    transaction_index,
+                })))
+            }
+            _ => Ok(None),
+        }
+    }
+}
+
 fn decode_hex_felt(hex: &str) -> std::result::Result<Vec<u8>, hex::FromHexError> {
     let hex = hex.trim_start_matches("0x");
     let hex = if hex.len() % 2 == 1 {
@@ -113,6 +256,29 @@ fn decode_hex_felt(hex: &str) -> std::result::Result<Vec<u8>, hex::FromHexError>
         hex.to_string()
     };
     hex::decode(&hex)
+}
+
+fn extract_result_u64(params: &serde_json::Value, field: &str) -> Option<u64> {
+    let result = match params {
+        serde_json::Value::Object(object) => object.get("result"),
+        serde_json::Value::Array(elements) => elements.get(1),
+        _ => None,
+    }?;
+
+    json_value_as_u64(result.get(field)?)
+}
+
+fn json_value_as_u64(value: &serde_json::Value) -> Option<u64> {
+    if let Some(value) = value.as_u64() {
+        return Some(value);
+    }
+
+    let value = value.as_str()?;
+    if let Some(value) = value.strip_prefix("0x") {
+        u64::from_str_radix(value, 16).ok()
+    } else {
+        value.parse().ok()
+    }
 }
 
 impl Stream for NewHeadsStream {
@@ -134,6 +300,30 @@ impl Stream for NewHeadsStream {
     }
 }
 
+impl Stream for StarknetLiveTransactionsStream {
+    type Item = Result<StarknetLiveMessage, StarknetProviderError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        loop {
+            match self.inner.poll_next_unpin(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Ready(Some(Ok(msg))) => match StarknetLiveMessage::try_from_message(msg) {
+                    Ok(None) => continue,
+                    Ok(Some(msg)) => return Poll::Ready(Some(Ok(msg))),
+                    Err(e) => return Poll::Ready(Some(Err(e))),
+                },
+                Poll::Ready(Some(Err(e))) => {
+                    let err = Err::<(), _>(e)
+                        .change_context(StarknetProviderError::Request)
+                        .unwrap_err();
+                    return Poll::Ready(Some(Err(err)));
+                }
+            }
+        }
+    }
+}
+
 impl SubscribeRequest {
     pub fn into_string(self) -> String {
         use serde_json::json;
@@ -150,5 +340,198 @@ impl SubscribeRequest {
 impl From<SubscribeRequest> for Message {
     fn from(r: SubscribeRequest) -> Self {
         Message::Text(r.into_string().into())
+    }
+}
+
+impl LiveSubscribeRequest {
+    pub fn into_string(self) -> String {
+        use serde_json::json;
+
+        let (id, method, params) = match self {
+            Self::NewTransactionReceipts(request) => (
+                1,
+                "starknet_subscribeNewTransactionReceipts",
+                serde_json::to_value(request).expect("serialization"),
+            ),
+            Self::NewTransactions(request) => (
+                2,
+                "starknet_subscribeNewTransactions",
+                serde_json::to_value(request).expect("serialization"),
+            ),
+        };
+
+        let payload = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        });
+        serde_json::to_string(&payload).expect("serialization")
+    }
+}
+
+impl From<LiveSubscribeRequest> for Message {
+    fn from(r: LiveSubscribeRequest) -> Self {
+        Message::Text(r.into_string().into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use starknet_rust::core::types::{
+        ExecutionResult, FeePayment, PriceUnit, TransactionFinalityStatus,
+    };
+
+    fn receipt_result(hash: &str, block_number: u64) -> serde_json::Value {
+        json!({
+            "type": "INVOKE",
+            "transaction_hash": hash,
+            "actual_fee": { "amount": "0x0", "unit": "FRI" },
+            "finality_status": "PRE_CONFIRMED",
+            "messages_sent": [],
+            "events": [],
+            "execution_resources": {
+                "l1_gas": 0,
+                "l1_data_gas": 0,
+                "l2_gas": 0
+            },
+            "execution_status": "SUCCEEDED",
+            "block_number": block_number,
+            "transaction_index": 7
+        })
+    }
+
+    fn transaction_result(hash: &str) -> serde_json::Value {
+        json!({
+            "type": "INVOKE",
+            "version": "0x1",
+            "transaction_hash": hash,
+            "sender_address": "0x1",
+            "calldata": [],
+            "max_fee": "0x0",
+            "signature": [],
+            "nonce": "0x0",
+            "finality_status": "PRE_CONFIRMED",
+            "block_number": 10,
+            "transaction_index": 3
+        })
+    }
+
+    #[test]
+    fn live_subscribe_requests_use_pre_confirmed_filters() {
+        let receipt_request = LiveSubscribeRequest::NewTransactionReceipts(
+            StarknetSubscribeNewTransactionReceiptsRequest {
+                finality_status: Some(vec![L2TransactionFinalityStatus::PreConfirmed]),
+                sender_address: None,
+            },
+        )
+        .into_string();
+        let receipt_request: serde_json::Value = serde_json::from_str(&receipt_request).unwrap();
+        assert_eq!(
+            receipt_request["method"],
+            "starknet_subscribeNewTransactionReceipts"
+        );
+        assert_eq!(
+            receipt_request["params"]["finality_status"],
+            json!(["PRE_CONFIRMED"])
+        );
+
+        let transaction_request =
+            LiveSubscribeRequest::NewTransactions(StarknetSubscribeNewTransactionsRequest {
+                finality_status: Some(vec![L2TransactionStatus::PreConfirmed]),
+                sender_address: None,
+                tags: None,
+            })
+            .into_string();
+        let transaction_request: serde_json::Value =
+            serde_json::from_str(&transaction_request).unwrap();
+        assert_eq!(
+            transaction_request["method"],
+            "starknet_subscribeNewTransactions"
+        );
+        assert_eq!(
+            transaction_request["params"]["finality_status"],
+            json!(["PRE_CONFIRMED"])
+        );
+    }
+
+    #[test]
+    fn parses_transaction_receipt_notification() {
+        let message = json!({
+            "jsonrpc": "2.0",
+            "method": "starknet_subscriptionNewTransactionReceipts",
+            "params": {
+                "subscription_id": "0x1",
+                "result": receipt_result("0x123", 10)
+            }
+        });
+
+        let parsed =
+            StarknetLiveMessage::try_from_message(Message::Text(message.to_string().into()))
+                .unwrap();
+
+        let Some(StarknetLiveMessage::Receipt(parsed)) = parsed else {
+            panic!("expected receipt notification");
+        };
+        assert_eq!(parsed.transaction_index, Some(7));
+        assert_eq!(parsed.receipt.block.block_number(), 10);
+        assert_eq!(
+            parsed.receipt.receipt.execution_result(),
+            &ExecutionResult::Succeeded
+        );
+        assert_eq!(
+            parsed.receipt.receipt.finality_status(),
+            &TransactionFinalityStatus::PreConfirmed
+        );
+        let actual_fee = match parsed.receipt.receipt {
+            starknet_rust::core::types::TransactionReceipt::Invoke(receipt) => receipt.actual_fee,
+            _ => panic!("expected invoke receipt"),
+        };
+        assert_eq!(
+            actual_fee,
+            FeePayment {
+                amount: starknet_rust::core::types::Felt::from_hex("0x0").unwrap(),
+                unit: PriceUnit::Fri
+            }
+        );
+    }
+
+    #[test]
+    fn parses_transaction_notification_and_ignores_subscribe_ack() {
+        let ack = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": "0xabc"
+        });
+        assert!(
+            StarknetLiveMessage::try_from_message(Message::Text(ack.to_string().into()))
+                .unwrap()
+                .is_none()
+        );
+
+        let message = json!({
+            "jsonrpc": "2.0",
+            "method": "starknet_subscriptionNewTransaction",
+            "params": {
+                "subscription_id": "0x2",
+                "result": transaction_result("0x123")
+            }
+        });
+
+        let parsed =
+            StarknetLiveMessage::try_from_message(Message::Text(message.to_string().into()))
+                .unwrap();
+
+        let Some(StarknetLiveMessage::Transaction(parsed)) = parsed else {
+            panic!("expected transaction notification");
+        };
+        assert_eq!(parsed.block_number, Some(10));
+        assert_eq!(parsed.transaction_index, Some(3));
+        assert_eq!(
+            parsed.transaction.finality_status,
+            L2TransactionStatus::PreConfirmed
+        );
     }
 }


### PR DESCRIPTION
## Problem

Starknet DNA pending ingestion currently depends on HTTP polling of `getBlockWithReceipts(PRE_CONFIRMED)` and `getStateUpdate(PRE_CONFIRMED)` before a pending DNA block can be written. Event and receipt-only consumers inherit state-update latency even though Starknet websocket subscriptions can deliver receipt/event payloads earlier.

There is also a moving-tag failure mode: the HTTP `PRE_CONFIRMED` tag can advance past a block that websocket subscriptions already pushed, so reducing the polling interval alone does not remove the race.

## Architecture

This adds an opt-in Starknet websocket live ingestion plane alongside the existing HTTP canonical path.

- Canonical HTTP ingestion remains responsible for backfill, accepted/finalized blocks, reorg reconciliation, state updates, storage diffs, nonces/contracts/classes, and optional traces.
- The live plane subscribes to `starknet_subscribeNewTransactionReceipts` with `PRE_CONFIRMED` and `starknet_subscribeNewTransactions` with `PRE_CONFIRMED`.
- `StarknetLiveAssembler` correlates transaction bodies and receipts by `transaction_hash`, orders by block/transaction index when present, and can emit receipt/event-only pending fragments when transaction bodies are not available.
- The common ingestion service now has a push update stream for pending blocks. WS receipt pushes schedule `tick_refresh_pending` immediately instead of waiting for the backup pending poll interval.
- Accepted canonical ingestion prunes optimistic live entries through the accepted block number.

## Compatibility

- Disabled by default.
- Enable with `STARKNET_WS_LIVE_INGESTION_ENABLED=true` plus `STARKNET_WS_URL`.
- Existing `STARKNET_INGEST_PRE_CONFIRMED=true` HTTP pending behavior remains available when websocket live ingestion is disabled.
- Accepted/finalized stream behavior is preserved; pushed blocks are optimistic pending data and are reconciled by the existing canonical path.
- TLS dependencies were moved to rustls-backed features to keep this workspace buildable without system OpenSSL/native-tls headers.

## Tests

Ran locally with `PROTOC=/workspace/death-mountain-client-vrf-settings-client/node_modules/.pnpm/node_modules/.bin/protoc`:

- `cargo fmt --check` - passed
- `git diff --check` - passed
- `cargo check --workspace` - passed
- `cargo test -p apibara-dna-starknet --lib` - passed, 8 tests

Additional common regression added: `test_ingestion_queues_pending_from_push_update_without_poll_interval`. It compiles, but running the existing `common/tests/test_ingestion_service.rs` fixture in this workspace is blocked before exercising the test because Docker/testcontainers cannot connect to `/var/run/docker.sock`.

## Benchmark

Harness added as:

```bash
cargo run -p apibara-benchmark -- starknet-live-latency \
  --direct-ws-url ws://64.34.87.87:9545/ws/rpc/v0_10 \
  --stream-url http://localhost:7007 \
  --game-core-address 0x023f86f5b4702f6ba114b82fb73448c58aad8f37a28b508b80bf129ee1edc405 \
  --game-event-key 0x03e037e958ba3b5c1cc99ac16aaf9896423eebd03183c41fbb26548a12336e5f
```

It prints per matched event:

```text
txHash,blockNumber,eventIndex,finality,directSubscribeEventsSeenMs,dnaStreamSeenMs,dnaMinusSubscribeEventsMs
```

The live latency benchmark was not run in this workspace because no local DNA server was listening on `localhost:7007`. Acceptance target for an environment with live traffic remains `p95DnaMinusSubscribeEventsMs <= 500`.

## Known Limitations

- WS live ingestion emits optimistic pending receipt/event data; state updates still come from HTTP/canonical reconciliation.
- Receipt/event-only filters can emit without transaction bodies. Filters that request transaction bodies may still wait for transaction-body subscription messages or a later pending generation.
- Reconnect currently re-subscribes and relies on canonical HTTP reconciliation for missed optimistic notifications.
